### PR TITLE
add option to retrieve optimistic/pessimistic values from DEA (2)

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -17,6 +17,7 @@ rule compile_cost_assumptions:
         expand("outputs/costs_{year}.csv", year = config["years"])
     threads: 1
     resources: mem=500
+    conda: "environment.yaml"
     script: "scripts/compile_cost_assumptions.py"
 
 
@@ -28,4 +29,5 @@ rule convert_fraunhofer:
         energy_prices = "inputs/Fraunhofer_ISE_energy_prices.csv"
     threads: 1
     resources: mem=500
+    conda: "environment.yaml"
     script: "scripts/convert_pdf_fraunhofer_to_dataframe.py"

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,14 @@
+name: technology-data
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python
+  - pip
+  - snakemake-minimal
+  - pandas>=1.1.0
+  - numpy
+  - beautifulsoup4
+
+  - pip:
+    - tabula-py

--- a/scripts/compile_cost_assumptions.py
+++ b/scripts/compile_cost_assumptions.py
@@ -253,8 +253,6 @@ def get_data_DEA(tech, data_in, expectation=None):
     if (tech == "offwind") and snakemake.config['offwind_no_gridcosts']:
         df.loc['Nominal investment (MEUR/MW)'] -= excel.loc[' - of which grid connection']
 
-    print(df)
-
     df_final = pd.DataFrame(index=df.index, columns=years)
 
     for index in df_final.index:


### PR DESCRIPTION
Second try:

You can now choose in the `config.yaml` whether you are an optimist, pessimist, realist (?!) (at least regarding techno-economic parameters) with `expectation: "optimist"`. We could also call it "conservative" and "progressive" if you like.

@lisazeyen, I decided against the additional wildcard for this setting, mainly because it was easier to code. 

There are quite a few cases where uncertainty ranges are not given for all parameters, only for some. If that happens, for missing parameters I take the central/main estimate (i.e. 2050) as filling value.

The columns "Lower" and "Upper" (from DEA) do not map directly onto "optimist" and "pessimist", because sometimes bigger values are better ("efficiency", "technical life"). This is accounted for as well.

In addition to "~" I delete the symbols ">" and "<".

Also adds and `environment.yaml` to the repository with version requirements. Can be used directly within `snakemake --use-conda ...` e.g. if embedded in a subworkflow.

It's not perfect:

- mildly hacky handling of technologies where no uncertainty range is given (copies central estimate into two columns s.t. pessimist = optimist = central estimate)
- only does linear interpolation between 2020 and 2050
- sometimes 2020 expectation values are already better than pessimistic 2050 values.