### PR TITLE
Take DEA CHP assumptions for c_b and c_v, not old PyPSA ones

### DIFF
--- a/outputs/costs_2020.csv
+++ b/outputs/costs_2020.csv
@@ -99,7 +99,7 @@ central coal CHP,investment,1900.0,EUR/kW,"Danish Energy Agency, technology_data
 central coal CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx",01 Coal CHP:  Technical lifetime
 central gas CHP,FOM,3.31,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP,VOM,4.4,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP,c_b,0.96,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP,efficiency,0.4,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP,investment,590.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -107,7 +107,7 @@ central gas CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_e
 central gas CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central gas CHP CCS,FOM,3.31,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP CCS,VOM,4.4,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP CCS,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP CCS,c_b,0.96,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP CCS,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP CCS,efficiency,0.36,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP CCS,investment,1190.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -133,8 +133,8 @@ central solar thermal,investment,140000.0,EUR/1000m2,HP, from old pypsa cost ass
 central solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions
 central solid biomass CHP,FOM,4.12,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP,VOM,1.86,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP,c_b,0.46,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP,efficiency,0.29,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP,investment,3006.8,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Nominal investment "
@@ -142,8 +142,8 @@ central solid biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_
 central solid biomass CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central solid biomass CHP CCS,FOM,4.12,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP CCS,VOM,1.86,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP CCS,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP CCS,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP CCS,c_b,0.46,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP CCS,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP CCS,efficiency,0.26,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP CCS,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP CCS,investment,3606.8,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","09b Wood Pellets, Medium:  Nominal investment "

--- a/outputs/costs_2025.csv
+++ b/outputs/costs_2025.csv
@@ -99,7 +99,7 @@ central coal CHP,investment,1880.24,EUR/kW,"Danish Energy Agency, technology_dat
 central coal CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx",01 Coal CHP:  Technical lifetime
 central gas CHP,FOM,3.31,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP,VOM,4.3,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP,c_b,0.98,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP,efficiency,0.4,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP,investment,575.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -107,7 +107,7 @@ central gas CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_e
 central gas CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central gas CHP CCS,FOM,3.31,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP CCS,VOM,4.3,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP CCS,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP CCS,c_b,0.98,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP CCS,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP CCS,efficiency,0.36,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP CCS,investment,1175.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -133,8 +133,8 @@ central solar thermal,investment,140000.0,EUR/1000m2,HP, from old pypsa cost ass
 central solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions
 central solid biomass CHP,FOM,4.11,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP,VOM,1.86,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP,c_b,0.46,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP,efficiency,0.29,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP,investment,2929.1,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Nominal investment "
@@ -142,8 +142,8 @@ central solid biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_
 central solid biomass CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central solid biomass CHP CCS,FOM,4.11,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP CCS,VOM,1.86,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP CCS,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP CCS,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP CCS,c_b,0.46,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP CCS,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP CCS,efficiency,0.26,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP CCS,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP CCS,investment,3529.1,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","09b Wood Pellets, Medium:  Nominal investment "

--- a/outputs/costs_2030.csv
+++ b/outputs/costs_2030.csv
@@ -99,7 +99,7 @@ central coal CHP,investment,1860.47,EUR/kW,"Danish Energy Agency, technology_dat
 central coal CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx",01 Coal CHP:  Technical lifetime
 central gas CHP,FOM,3.32,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP,VOM,4.2,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP,efficiency,0.41,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP,investment,560.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -107,7 +107,7 @@ central gas CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_e
 central gas CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central gas CHP CCS,FOM,3.32,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP CCS,VOM,4.2,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP CCS,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP CCS,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP CCS,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP CCS,efficiency,0.37,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP CCS,investment,1160.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -133,8 +133,8 @@ central solar thermal,investment,140000.0,EUR/1000m2,HP, from old pypsa cost ass
 central solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions
 central solid biomass CHP,FOM,4.1,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP,VOM,1.85,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP,c_b,0.46,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP,efficiency,0.29,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP,investment,2851.41,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Nominal investment "
@@ -142,8 +142,8 @@ central solid biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_
 central solid biomass CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central solid biomass CHP CCS,FOM,4.1,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP CCS,VOM,1.85,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP CCS,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP CCS,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP CCS,c_b,0.46,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP CCS,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP CCS,efficiency,0.26,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP CCS,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP CCS,investment,3451.41,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","09b Wood Pellets, Medium:  Nominal investment "

--- a/outputs/costs_2035.csv
+++ b/outputs/costs_2035.csv
@@ -99,7 +99,7 @@ central coal CHP,investment,1841.32,EUR/kW,"Danish Energy Agency, technology_dat
 central coal CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx",01 Coal CHP:  Technical lifetime
 central gas CHP,FOM,3.35,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP,VOM,4.15,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP,efficiency,0.42,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP,investment,550.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -107,7 +107,7 @@ central gas CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_e
 central gas CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central gas CHP CCS,FOM,3.35,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP CCS,VOM,4.15,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP CCS,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP CCS,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP CCS,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP CCS,efficiency,0.37,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP CCS,investment,1150.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -133,8 +133,8 @@ central solar thermal,investment,140000.0,EUR/1000m2,HP, from old pypsa cost ass
 central solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions
 central solid biomass CHP,FOM,4.07,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP,VOM,1.86,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP,c_b,0.46,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP,efficiency,0.29,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP,investment,2817.11,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Nominal investment "
@@ -142,8 +142,8 @@ central solid biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_
 central solid biomass CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central solid biomass CHP CCS,FOM,4.07,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP CCS,VOM,1.86,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP CCS,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP CCS,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP CCS,c_b,0.46,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP CCS,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP CCS,efficiency,0.26,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP CCS,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP CCS,investment,3417.11,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","09b Wood Pellets, Medium:  Nominal investment "

--- a/outputs/costs_2040.csv
+++ b/outputs/costs_2040.csv
@@ -99,7 +99,7 @@ central coal CHP,investment,1822.17,EUR/kW,"Danish Energy Agency, technology_dat
 central coal CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx",01 Coal CHP:  Technical lifetime
 central gas CHP,FOM,3.39,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP,VOM,4.1,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP,efficiency,0.42,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP,investment,540.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -107,7 +107,7 @@ central gas CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_e
 central gas CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central gas CHP CCS,FOM,3.39,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP CCS,VOM,4.1,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP CCS,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP CCS,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP CCS,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP CCS,efficiency,0.38,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP CCS,investment,1140.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -133,8 +133,8 @@ central solar thermal,investment,140000.0,EUR/1000m2,HP, from old pypsa cost ass
 central solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions
 central solid biomass CHP,FOM,4.04,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP,VOM,1.87,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP,c_b,0.45,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP,efficiency,0.29,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP,investment,2782.81,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Nominal investment "
@@ -142,8 +142,8 @@ central solid biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_
 central solid biomass CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central solid biomass CHP CCS,FOM,4.04,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP CCS,VOM,1.87,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP CCS,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP CCS,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP CCS,c_b,0.45,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP CCS,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP CCS,efficiency,0.26,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP CCS,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP CCS,investment,3382.81,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","09b Wood Pellets, Medium:  Nominal investment "

--- a/outputs/costs_2045.csv
+++ b/outputs/costs_2045.csv
@@ -99,7 +99,7 @@ central coal CHP,investment,1803.02,EUR/kW,"Danish Energy Agency, technology_dat
 central coal CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx",01 Coal CHP:  Technical lifetime
 central gas CHP,FOM,3.42,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP,VOM,4.05,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP,efficiency,0.42,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP,investment,530.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -107,7 +107,7 @@ central gas CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_e
 central gas CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central gas CHP CCS,FOM,3.42,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP CCS,VOM,4.05,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP CCS,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP CCS,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP CCS,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP CCS,efficiency,0.38,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP CCS,investment,1130.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -133,8 +133,8 @@ central solar thermal,investment,140000.0,EUR/1000m2,HP, from old pypsa cost ass
 central solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions
 central solid biomass CHP,FOM,4.01,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP,VOM,1.88,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP,c_b,0.45,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP,efficiency,0.29,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP,investment,2748.51,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Nominal investment "
@@ -142,8 +142,8 @@ central solid biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_
 central solid biomass CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central solid biomass CHP CCS,FOM,4.01,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP CCS,VOM,1.88,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP CCS,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP CCS,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP CCS,c_b,0.45,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP CCS,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP CCS,efficiency,0.26,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP CCS,efficiency-heat,0.69,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP CCS,investment,3348.51,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","09b Wood Pellets, Medium:  Nominal investment "

--- a/outputs/costs_2050.csv
+++ b/outputs/costs_2050.csv
@@ -99,7 +99,7 @@ central coal CHP,investment,1783.87,EUR/kW,"Danish Energy Agency, technology_dat
 central coal CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx",01 Coal CHP:  Technical lifetime
 central gas CHP,FOM,3.46,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP,VOM,4.0,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP,efficiency,0.43,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP,investment,520.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -107,7 +107,7 @@ central gas CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_e
 central gas CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central gas CHP CCS,FOM,3.46,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M"
 central gas CHP CCS,VOM,4.0,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Variable O&M"
-central gas CHP CCS,c_b,0.7,per unit,DEA (backpressure ratio), from old pypsa cost assumptions
+central gas CHP CCS,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient"
 central gas CHP CCS,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions
 central gas CHP CCS,efficiency,0.39,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average"
 central gas CHP CCS,investment,1120.0,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","04 Gas turb. simple cycle, L:  Nominal investment"
@@ -133,8 +133,8 @@ central solar thermal,investment,140000.0,EUR/1000m2,HP, from old pypsa cost ass
 central solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions
 central solid biomass CHP,FOM,3.98,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP,VOM,1.88,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP,c_b,0.45,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP,efficiency,0.29,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP,efficiency-heat,0.7,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP,investment,2714.2,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Nominal investment "
@@ -142,8 +142,8 @@ central solid biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_
 central solid biomass CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions
 central solid biomass CHP CCS,FOM,3.98,%/year,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Fixed O&M"
 central solid biomass CHP CCS,VOM,1.88,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Variable O&M "
-central solid biomass CHP CCS,c_b,1.01,per unit,DEA for wood pellets CHP (backpressure ratio), from old pypsa cost assumptions
-central solid biomass CHP CCS,c_v,0.15,per unit,DEA for wood pellets CHP (loss of fuel for additional heat), from old pypsa cost assumptions
+central solid biomass CHP CCS,c_b,0.45,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cb coefficient"
+central solid biomass CHP CCS,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Cv coefficient"
 central solid biomass CHP CCS,efficiency,0.26,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Electricity efficiency, net, annual average"
 central solid biomass CHP CCS,efficiency-heat,0.7,per unit,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx","09b Wood Pellets, Medium:  Heat efficiency, net, annual average"
 central solid biomass CHP CCS,investment,3314.2,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh_-_0009.xlsx , DIW (CCS)","09b Wood Pellets, Medium:  Nominal investment "

--- a/scripts/compile_cost_assumptions.py
+++ b/scripts/compile_cost_assumptions.py
@@ -1016,20 +1016,12 @@ for year in years:
     # single components missing
     comp_missing = costs_pypsa.index.difference(costs_tot.index)
     if (year==years[0]):
-        print("singlle parameters of technologies are missing: ")
+        print("single parameters of technologies are missing, using old PyPSA assumptions: ")
         print(comp_missing)
         print("old c_v and c_b values are assumed where given")
     to_add = costs_pypsa.loc[comp_missing].drop("year", axis=1)
     to_add.loc[:, "further description"] = " from old pypsa cost assumptions"
     costs_tot = pd.concat([costs_tot, to_add], sort=False)
-
-    # take c_v and c_b values from old cost assumptions TODO check again!
-    c_value_index =  costs_pypsa[costs_pypsa.index.get_level_values(1).isin(
-                                ["c_b", "c_v"])].index
-    costs_tot.loc[c_value_index,
-                  ["value", "unit", "source"]] = costs_pypsa.loc[c_value_index,
-                                                       ["value", "unit", "source"]]
-    costs_tot.loc[c_value_index, "further description"] = " from old pypsa cost assumptions"
 
     # unify the cost from DIW2010
     costs_tot = unify_diw(costs_tot)


### PR DESCRIPTION
This PR stops the script replacing the DEA values for the back pressure coefficient c_b and the c_v value with the old PyPSA values.

The old PyPSA values for c_b and c_v assume an extraction plant (like the DEA coal CHP) which has flexible production of heat and electricity within the feasibility diagram of Figure 4 in the [Synergies paper](https://arxiv.org/abs/1801.05290).

However, if you look in DEA assumptions at "09b Wood Pellets Medium" (used for solid biomass CHP) and "Gas turbine simple cycle (large)" (used for gas CHP) they are not extraction plants but back pressure plants.

The back pressure coefficient in DEA c_b is simply:

c_b = name plate electricity efficiency / name plate heat efficiency

both measured when both heat and electricity are produced at maximum.

For the extraction plants, the efficiency is measured in condensation mode, i.e. no heat production.

With the old assumptions, the solid biomass CHP was under-producing heat for a given fuel input.

In our simulation results the plants produce along the back pressure line anyway for 99.5% of the time, so we don't need the full feasibility space.

I've correct the implementation in the PyPSA-Eur-Sec code too, see:

https://github.com/PyPSA/pypsa-eur-sec/commit/098281b432c69d51c502a9d515494867059191bf

The CHPs are now implemented as single links with heat output proportional to electricity output.