### PR TITLE
Use targets and realtive line numbers for code references in docs

### DIFF
--- a/docs/addnew.rst
+++ b/docs/addnew.rst
@@ -18,7 +18,8 @@ compiled correctly.
 
 .. literalinclude:: ../scripts/compile_cost_assumptions.py
    :language: python
-   :lines: 54-60, 94
+   :start-after: [DEA-sheet-names]
+   :end-before: [DEA-sheet-names]
 
 If you want to extract further parameters from the DEA excel sheets you can
 add them to the ``parameter`` list in the function ``get_data_DEA()``.
@@ -33,14 +34,16 @@ and four columns (``['value', 'unit', 'source', 'further description']``).
 
 .. literalinclude:: ../scripts/compile_cost_assumptions.py
    :language: python
-   :lines: 1032-1036
+   :start-after: [RTD-target-multiindex-df]
+   :lines: 1-4
 
 The function for the newly added technology should extend this pandas Dataframe
 ``costs``. This is done for example for solar PV costs in the function `add_solar_from_other(costs) <https://github.com/PyPSA/technology-data/blob/2f4da6d75f07ef9457f4070b26d690f1e5e932a5/scripts/compile_cost_assumptions.py#L396>`_
 
 .. literalinclude:: ../scripts/compile_cost_assumptions.py
    :language: python
-   :lines: 396-400
+   :start-after: [add-solar-from-others]
+   :lines: 1-4
 
 If a new technology is added, existing parameter names (e.g. "investment") and
 units (e.g. EUR/MW) should be used. If the energy output is not distinct, clarify
@@ -65,7 +68,8 @@ as it is done for example for the cost assumptions from DIW from 2010
 
 .. literalinclude:: ../scripts/compile_cost_assumptions.py
    :language: python
-   :lines: 477
+   :start-after: [unify-diw-inflation]
+   :lines: 1-5
 
 The output cost assumptions are given for different years. So either the added
 cost assumptions have to be interpolated for different in the ``config.yaml``
@@ -73,11 +77,13 @@ specified years, as done e.g. with the technology data from DEA `here <https://g
 
 .. literalinclude:: ../scripts/compile_cost_assumptions.py
    :language: python
-   :lines: 259
+   :start-after: [RTD-interpolation-example]
+   :lines: 1-3
 
 or the technology data is assumed to be constant for the different years, as e.g.
 done if other electrolyzer data is assumed in this `function <https://github.com/PyPSA/technology-data/blob/2f4da6d75f07ef9457f4070b26d690f1e5e932a5/scripts/compile_cost_assumptions.py#L443>`_.
 
 .. literalinclude:: ../scripts/compile_cost_assumptions.py
    :language: python
-   :lines: 443-450
+   :start-after: [add-h2-from-other]
+   :lines: 1-10

--- a/scripts/compile_cost_assumptions.py
+++ b/scripts/compile_cost_assumptions.py
@@ -49,8 +49,7 @@ source_dict = {
 
                 }
 
-# ---- sheet names for techs in DEA ------------------------------------------
-
+# [DEA-sheet-names]
 sheet_names = {'onwind': '20 Onshore turbines',
                'offwind': '21 Offshore turbines',
                'solar-utility': '22 Photovoltaics Large',
@@ -95,6 +94,7 @@ sheet_names = {'onwind': '20 Onshore turbines',
                # 'gas pipeline': '102 6 gas Main distri line',
                # "DH main transmission": "103_11 DH transmission",
                }
+# [DEA-sheet-names]
 
 uncrtnty_lookup = {'onwind': 'J:K',
                     'offwind': 'J:K',
@@ -267,6 +267,7 @@ def get_data_DEA(tech, data_in, expectation=None):
 
     df_final = pd.DataFrame(index=df.index, columns=years)
 
+    # [RTD-interpolation-example]
     for index in df_final.index:
         values = np.interp(x=years, xp=df.columns.values.astype(float), fp=df.loc[index, :].values.astype(float))
         df_final.loc[index, :] = values
@@ -277,7 +278,6 @@ def get_data_DEA(tech, data_in, expectation=None):
     df_final.index = df_final.index.str.replace(r" \(.*\)","")
 
     return df_final
-
 
 def add_conventional_data(costs):
     """"
@@ -391,12 +391,13 @@ def add_co2_intensity(costs):
 
     return costs
 
-
+# [add-solar-from-others]
 def add_solar_from_other(costs):
     """"
     add solar from other sources than DEA (since the life time assumed in
     DEA is very optimistic)
     """
+
     # solar utility from Vartiaian 2019
     data = np.interp(x=years, xp=[2020, 2030, 2040, 2050],
                      fp=[431, 275, 204, 164])
@@ -438,7 +439,7 @@ def add_solar_from_other(costs):
 
     return costs
 
-
+# [add-h2-from-other]
 def add_h2_from_other(costs):
     """
     assume higher efficiency for electrolysis(0.8) and fuel cell(0.58)
@@ -450,7 +451,7 @@ def add_h2_from_other(costs):
 
     return costs
 
-
+# [unify-diw-inflation]
 def unify_diw(costs):
     """"
     include inflation for the DIW costs from 2010
@@ -1044,6 +1045,7 @@ costs_ISE = rename_ISE(costs_ISE)
 data = pd.concat([data, costs_ISE.loc[["Gasnetz"]]], sort=True)
 
 # %% (3) ------ add additional sources and save cost as csv ------------------
+# [RTD-target-multiindex-df]
 for year in years:
     costs = (data[[year, "unit", "source", "further description"]]
              .rename(columns={year: "value"}))


### PR DESCRIPTION
Using only line numbers breaks the code reference in the documentation when the line numbers change.
This PR introduces RST targets which are more robust.

(Untested, my local SPHINX is not setup).