### PR TITLE
Fix pandas str.replace regex=True default deprecation.

### DIFF
--- a/scripts/compile_cost_assumptions.py
+++ b/scripts/compile_cost_assumptions.py
@@ -275,7 +275,7 @@ def get_data_DEA(tech, data_in, expectation=None):
     df_final["source"] = source_dict["DEA"] + ", " + excel_file.replace("inputs/","")
     df_final["unit"] = (df_final.rename(index=lambda x:
                                         x[x.rfind("(")+1: x.rfind(")")]).index.values)
-    df_final.index = df_final.index.str.replace(r" \(.*\)","")
+    df_final.index = df_final.index.str.replace(r" \(.*\)","", regex=True)
 
     return df_final
 


### PR DESCRIPTION
See https://pandas.pydata.org/docs/whatsnew/v1.2.0.html#deprecationse .

Soon the current default `regex=True` will be `regex=False`.

This PR adds then necessary flag.