### PR TITLE
New hydrogen storage tank type 1 costs

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,8 @@ Upcoming Release
 
 * New technologies
   - new biomass technologies (BioSNG, BtL, biogas, biogas plus hydrogen, digestible biomass,digestible biomass to hydrogen, electric boiler steam, gas boiler steam, industrial heat pump high temperature, solid biomass boiler steam, solid bioass to hydrogen, biomass boiler for decentral heating
+  - hydrogen storage tank type 1: Low pressure hydrogen tank storage (up to 200 bar)
+  - hydrogen storage compressor: Compressor for filling hydrogen storage tanks (compression from 30 to 250 bar)
 
 Technology-Data 0.4.0 (22 July 2022)
 ===========================================

--- a/inputs/manual_input.csv
+++ b/inputs/manual_input.csv
@@ -216,7 +216,7 @@ hydrogen storage tank type 1,investment,2030,13.5,EUR/kWh_H2,2020,"Based on Stö
 hydrogen storage tank type 1,FOM,2030,2,%/year,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-
 hydrogen storage tank type 1,lifetime,2030,20,years,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-
 hydrogen storage tank type 1,min_fill_level,2030,6,%,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-
-hydrogen compressor,investment,2030,87.69,EUR/kWh_H2,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.","2923 EUR/kg_H2. For a 206 kg/h compressor. Base CAPEX 40 528 EUR/kW_el with scale factor 0.4603. kg_H2 converted to MWh using LHV. Pressure range: 30 bar in, 250 bar out."
-hydrogen compressor,FOM,2030,4,%/year,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-
-hydrogen compressor,lifetime,2030,15,years,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-
-hydrogen compressor,compression-electricity-input,2030,0.05,MWh_el/MWh_H2,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",1.707 kWh/kg.
+hydrogen storage compressor,investment,2030,87.69,EUR/kWh_H2,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.","2923 EUR/kg_H2. For a 206 kg/h compressor. Base CAPEX 40 528 EUR/kW_el with scale factor 0.4603. kg_H2 converted to MWh using LHV. Pressure range: 30 bar in, 250 bar out."
+hydrogen storage compressor,FOM,2030,4,%/year,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-
+hydrogen storage compressor,lifetime,2030,15,years,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-
+hydrogen storage compressor,compression-electricity-input,2030,0.05,MWh_el/MWh_H2,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",1.707 kWh/kg.

--- a/inputs/manual_input.csv
+++ b/inputs/manual_input.csv
@@ -212,3 +212,11 @@ csp-tower power block,lifetime,2020,30,years,2020,see solar-tower.,-
 csp-tower power block,lifetime,2030,30,years,2020,see solar-tower.,-
 csp-tower power block,lifetime,2040,30,years,2020,see solar-tower.,-
 csp-tower power block,lifetime,2050,30,years,2020,see solar-tower.,-
+hydrogen storage tank type 1,investment,2030,13.5,EUR/kWh_H2,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.","450 EUR/kg_H2 converted with LHV to MWh. For a type 1 hydrogen storage tank (steel, 15-250 bar). Currency year assumed 2020 for initial publication of reference; observe note in SI.4.3 that no currency year is explicitly stated in the reference."
+hydrogen storage tank type 1,FOM,2030,2,%/year,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-
+hydrogen storage tank type 1,lifetime,2030,20,years,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-
+hydrogen storage tank type 1,min_fill_level,2030,6,%,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-
+hydrogen compressor,investment,2030,87.69,EUR/kWh_H2,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.","2923 EUR/kg_H2. For a 206 kg/h compressor. Base CAPEX 40 528 EUR/kW_el with scale factor 0.4603. kg_H2 converted to MWh using LHV. Pressure range: 30 bar in, 250 bar out."
+hydrogen compressor,FOM,2030,4,%/year,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-
+hydrogen compressor,lifetime,2030,15,years,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-
+hydrogen compressor,compression-electricity-input,2030,0.05,MWh_el/MWh_H2,2020,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",1.707 kWh/kg.

--- a/outputs/costs_2020.csv
+++ b/outputs/costs_2020.csv
@@ -420,11 +420,19 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
+hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.05,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M
 hydrogen storage tank incl. compressor,investment,57.0,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment
 hydrogen storage tank incl. compressor,lifetime,25.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime
+hydrogen storage tank type 1,FOM,2.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,investment,12.23,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,lifetime,20.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,min_fill_level,6.0,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
 hydrogen storage underground,FOM,0.0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M
 hydrogen storage underground,VOM,0.0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M
 hydrogen storage underground,investment,3.0,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment

--- a/outputs/costs_2020.csv
+++ b/outputs/costs_2020.csv
@@ -420,10 +420,10 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
-hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.05,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M

--- a/outputs/costs_2025.csv
+++ b/outputs/costs_2025.csv
@@ -420,11 +420,19 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
+hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.08,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M
 hydrogen storage tank incl. compressor,investment,50.96,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment
 hydrogen storage tank incl. compressor,lifetime,27.5,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime
+hydrogen storage tank type 1,FOM,2.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,investment,12.23,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,lifetime,20.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,min_fill_level,6.0,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
 hydrogen storage underground,FOM,0.0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M
 hydrogen storage underground,VOM,0.0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M
 hydrogen storage underground,investment,2.5,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment

--- a/outputs/costs_2025.csv
+++ b/outputs/costs_2025.csv
@@ -420,10 +420,10 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
-hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.08,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M

--- a/outputs/costs_2030.csv
+++ b/outputs/costs_2030.csv
@@ -420,10 +420,10 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
-hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.11,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M

--- a/outputs/costs_2030.csv
+++ b/outputs/costs_2030.csv
@@ -420,11 +420,19 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
+hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.11,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M
 hydrogen storage tank incl. compressor,investment,44.91,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment
 hydrogen storage tank incl. compressor,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime
+hydrogen storage tank type 1,FOM,2.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,investment,12.23,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,lifetime,20.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,min_fill_level,6.0,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
 hydrogen storage underground,FOM,0.0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M
 hydrogen storage underground,VOM,0.0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M
 hydrogen storage underground,investment,2.0,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment

--- a/outputs/costs_2035.csv
+++ b/outputs/costs_2035.csv
@@ -420,11 +420,19 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
+hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.39,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M
 hydrogen storage tank incl. compressor,investment,35.98,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment
 hydrogen storage tank incl. compressor,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime
+hydrogen storage tank type 1,FOM,2.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,investment,12.23,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,lifetime,20.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,min_fill_level,6.0,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
 hydrogen storage underground,FOM,0.0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M
 hydrogen storage underground,VOM,0.0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M
 hydrogen storage underground,investment,1.75,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment

--- a/outputs/costs_2035.csv
+++ b/outputs/costs_2035.csv
@@ -420,10 +420,10 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
-hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.39,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M

--- a/outputs/costs_2040.csv
+++ b/outputs/costs_2040.csv
@@ -420,10 +420,10 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
-hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.85,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M

--- a/outputs/costs_2040.csv
+++ b/outputs/costs_2040.csv
@@ -420,11 +420,19 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
+hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.85,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M
 hydrogen storage tank incl. compressor,investment,27.05,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment
 hydrogen storage tank incl. compressor,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime
+hydrogen storage tank type 1,FOM,2.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,investment,12.23,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,lifetime,20.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,min_fill_level,6.0,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
 hydrogen storage underground,FOM,0.0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M
 hydrogen storage underground,VOM,0.0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M
 hydrogen storage underground,investment,1.5,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment

--- a/outputs/costs_2045.csv
+++ b/outputs/costs_2045.csv
@@ -420,10 +420,10 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
-hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.87,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M

--- a/outputs/costs_2045.csv
+++ b/outputs/costs_2045.csv
@@ -420,11 +420,19 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
+hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.87,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M
 hydrogen storage tank incl. compressor,investment,24.03,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment
 hydrogen storage tank incl. compressor,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime
+hydrogen storage tank type 1,FOM,2.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,investment,12.23,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,lifetime,20.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,min_fill_level,6.0,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
 hydrogen storage underground,FOM,0.0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M
 hydrogen storage underground,VOM,0.0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M
 hydrogen storage underground,investment,1.35,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment

--- a/outputs/costs_2050.csv
+++ b/outputs/costs_2050.csv
@@ -420,10 +420,10 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
-hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
-hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen storage compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.9,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M

--- a/outputs/costs_2050.csv
+++ b/outputs/costs_2050.csv
@@ -420,11 +420,19 @@ hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pyp
 hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,investment,2208.16,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions
 hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions
+hydrogen compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,investment,79.42,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
+hydrogen compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",
 hydrogen storage tank,investment,11.2,USD/kWh,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank,lifetime,20.0,years,budischak2013, from old pypsa cost assumptions
 hydrogen storage tank incl. compressor,FOM,1.9,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M
 hydrogen storage tank incl. compressor,investment,21.0,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment
 hydrogen storage tank incl. compressor,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime
+hydrogen storage tank type 1,FOM,2.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,investment,12.23,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,lifetime,20.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
+hydrogen storage tank type 1,min_fill_level,6.0,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",
 hydrogen storage underground,FOM,0.0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M
 hydrogen storage underground,VOM,0.0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M
 hydrogen storage underground,investment,1.2,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment


### PR DESCRIPTION
Add new cost assumptions for hydrogen storage tanks (type 1 class storage). Also adds hydrogen storage compressor costs.

These costs are different and lower than the current costs (`hydrogen storage tank incl. compressor`) which are from DEA assume 200bar hydrogen storage in tanks. The new costs also seperate the two technologies.

They are based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464 which is the same source as used in [this FSR study](https://cadmus.eui.eu/bitstream/handle/1814/74850/RSC_WP_2022_44.pdf?sequence=1&isAllowed=y). Stöckl et al. themselves base their value on the HDSAM 3.0 model, to which an update (3.1) exists but in which I wasn't able to find the parameters. 

The name of the already used technology was not changed or the technology removed to preseve compatability.

## Changes proposed in this Pull Request


## Checklist

- [n/a] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Data source for new technologies is cleary stated.
- [n/a] Newly introduced dependencies are added to `environment.yaml` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the GPLv3 license.
