### PR TITLE
Allow `currency_year` in `manual_input.csv` to be empty

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,11 +13,14 @@ Upcoming Release
   - hydrogen storage tank type 1: Low pressure hydrogen tank storage (up to 200 bar)
   - hydrogen storage compressor: Compressor for filling hydrogen storage tanks (compression from 30 to 250 bar)
 
-* Enable easy debugging of scripts by allowing python execution/ debugging in scripts
-
-* Breaking changes
+* Changed technologies
   - Renamed "hydrogen storage tank incl. compressor" to "hydrogen storage tank type 1 including compressor" for more clarity on the technology and consistency
   - Removed "hydrogen storage tank" technology assumption from old PyPSA assumptions which is superceeded by the "hydrogen storage tank type 1" assumptions
+
+* Features
+  - Enable easy debugging of scripts by allowing python execution/ debugging in scripts
+  - The column "currency_year" in "manual_input.csv" can now be left blank and is only evaluated for "investment" and "VOM" entries
+
 
 Technology-Data 0.4.0 (22 July 2022)
 ===========================================

--- a/scripts/compile_cost_assumptions.py
+++ b/scripts/compile_cost_assumptions.py
@@ -1230,7 +1230,7 @@ def add_manual_input(data):
 
     # Inflation adjustment for investment and VOM
     mask = df[df['parameter'].isin(['investment','VOM'])].index
-    df.loc[mask, 'value'] /= (1+snakemake.config['rate_inflation'])**(df.loc[mask, 'currency_year']-snakemake.config['eur_year'])
+    df.loc[mask, 'value'] /= (1+snakemake.config['rate_inflation'])**(df.loc[mask, 'currency_year'].astype(int)-snakemake.config['eur_year'])
 
     l = []
     for tech in df['technology'].unique():


### PR DESCRIPTION
## Changes proposed in this Pull Request

Before the `currency_year` needed to be a numeric value. Restriction is now lifted.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [n/a] Data source for new technologies is cleary stated.
- [n/a] Newly introduced dependencies are added to `environment.yaml` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the GPLv3 license.
