### PR TITLE
upload outputs directory as artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,3 +17,8 @@ jobs:
       shell: bash -l {0}
       run: |
         snakemake --cores all -f compile_cost_assumptions
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: technology-data
+        path: outputs/


### PR DESCRIPTION
As a preparatory step to remove `outputs` from git repository.