### PR TITLE
bugfixing for optimist and pessimist cost data and fixing environment yaml

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -8,7 +8,7 @@ rule compile_cost_assumptions:
         pypsa_costs = "inputs/costs_PyPSA.csv",
         fraunhofer_costs = "inputs/Fraunhofer_ISE_costs.csv",
         fraunhofer_energy_prices = "inputs/Fraunhofer_ISE_energy_prices.csv",
-	    fraunhofer_vehicles_costs = "inputs/Fraunhofer_ISE_vehicles_costs.csv",
+        fraunhofer_vehicles_costs = "inputs/Fraunhofer_ISE_vehicles_costs.csv",
         EWG_costs = "inputs/EWG_costs.csv",
         dea_transport = "inputs/energy_transport_data_sheet_dec_2017.xlsx",
         dea_renewable_fuels = "inputs/data_sheets_for_renewable_fuels.xlsx",

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
   - beautifulsoup4
   - xlrd
   - scipy
-  - openpyxl<=3.1.0
+  - openpyxl>=3.1.2
   - packaging
 
   - pip:

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,10 +3,13 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python>=3.9,<3.11
+  - python>=3.8
   - pip
-  - snakemake-minimal
-  - pandas>=1.1.0
+  # for debugging
+  - pypsa>=0.26.1
+  # for running the package
+  - snakemake-minimal>=8.5
+  - pandas>=2.1
   - numpy
   - beautifulsoup4
   - xlrd

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,8 +5,6 @@ channels:
 dependencies:
   - python>=3.8
   - pip
-  # for debugging
-  - pypsa>=0.26.1
   # for running the package
   - snakemake-minimal>=8.5
   - pandas>=2.1

--- a/scripts/compile_cost_assumptions.py
+++ b/scripts/compile_cost_assumptions.py
@@ -344,6 +344,8 @@ def get_data_DEA(tech, data_in, expectation=None):
     excel.loc[swap, "2050-optimist"] = tmp
 
     if expectation:
+        # drop duplicates
+        excel = excel[~excel.index.duplicated()]
         excel.loc[:,2050] = excel.loc[:,f"2050-{expectation}"].combine_first(excel.loc[:,2050])
     excel.drop(columns=uncertainty_columns, inplace=True)
 
@@ -1039,6 +1041,8 @@ def order_data(tech_data):
                 clean_df[tech] = pd.concat([clean_df[tech], fixed])
                 fom = pd.DataFrame(columns=fixed.columns)
                 if not any(fixed.unit.str.contains('% of specific investment/year')):
+                    investment[investment==0] = float('nan')
+                    investment = investment.ffill(axis=1).fillna(0)
                     fom[years] = fixed[years]/investment[years].values*100
                 else:
                     fom[years] = fixed[years]


### PR DESCRIPTION
Optimist and Pessimist cost data did not work due to two minor bugs.
Maybe think about adding them to the CI check since running technology-data does not take too much time.
The environment.yaml was not working for the mock_snakemake.
Missing packages like pypsa and snakemake version > 8.0 necessary.

Closes # (if applicable).

## Changes proposed in this Pull Request
- bugfixing
- updating environment.yaml

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Data source for new technologies is cleary stated.
- [x] Newly introduced dependencies are added to `environment.yaml` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the GPLv3 license.
