### PR TITLE
replaced ssh git clone command with https variant to allow for easier…

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,7 +15,7 @@ Clone the repository `technology-data <https://github.com/PyPSA/technology-data>
 
 .. code:: bash
 
-    projects % git clone git@github.com:PyPSA/technology-data.git
+    projects % git clone https://github.com/PyPSA/technology-data.git
 
 If you want to use the technology-data with `PyPSA-Eur <https://github.com/PyPSA/pypsa-eur>`_ or `PyPSA-Eur-Sec <https://github.com/PyPSA/pypsa-eur-sec>`_ the repository should be cloned in a parallel directory.
 


### PR DESCRIPTION
… setup

With SSH variant one gets

Cloning into 'technology-data'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.

and the benefit of  setting up SSH connection is not worth the effort in this case, I would say

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Data source for new technologies is clearly stated.
- [ ] Newly introduced dependencies are added to `environment.yaml` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the GPLv3 license.
