### PR TITLE
add missing currency_year for FOM

### DIFF
--- a/inputs/manual_input.csv
+++ b/inputs/manual_input.csv
@@ -185,14 +185,14 @@ Ammonia cracker,FOM,2050,4.3,%/year,2015,"Ishimoto et al. (2020): 10.1016/j.ijhy
 Ammonia cracker,ammonia-input,0,1.46,MWh_NH3/MWh_H2,,"ENGIE et al (2020): Ammonia to Green Hydrogen Feasibility Study (https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/880826/HS420_-_Ecuity_-_Ammonia_to_Green_Hydrogen.pdf), Fig. 10.",Assuming a integrated 200t/d cracking and purification facility. Electricity demand (316 MWh per 2186 MWh_LHV H2 output) is assumed to also be ammonia LHV input which seems a fair assumption as the facility has options for a higher degree of integration according to the report).
 methanol-to-olefins/aromatics,investment,2015,2628000,EUR/(t_HVC/h),2015,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",Assuming CAPEX of 1200 €/t actually given in €/(t/a).
 methanol-to-olefins/aromatics,lifetime,2015,30,years,-,Guesstimate,same as steam cracker
-methanol-to-olefins/aromatics,FOM,2015,3,%/year,-,Guesstimate,same as steam cracker
+methanol-to-olefins/aromatics,FOM,2015,3,%/year,2015,Guesstimate,same as steam cracker
 methanol-to-olefins/aromatics,VOM,2015,30,€/t_HVC,2015,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", 
 methanol-to-olefins/aromatics,electricity-input,2015,1.3889,MWh_el/t_HVC,-,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), page 69",5 GJ/t_HVC 
 methanol-to-olefins/aromatics,methanol-input,2015,18.03,MWh_MeOH/t_HVC,-,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 2.83 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 4.2 t_MeOH/t_BTX for 15.7 Mt of BTX. Assuming 5.54 MWh_MeOH/t_MeOH. "
 methanol-to-olefins/aromatics,carbondioxide-output,2015,0.6107,t_CO2/t_HVC,-,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 0.4 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 1.13 t_CO2/t_BTX for 15.7 Mt of BTX. The report also references process emissions of 0.55 t_MeOH/t_ethylene+propylene elsewhere. "
 electric steam cracker,investment,2015,10512000,EUR/(t_HVC/h),2015,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",Assuming CAPEX of 1200 €/t actually given in €/(t/a).
 electric steam cracker,lifetime,2015,30,years,-,Guesstimate,
-electric steam cracker,FOM,2015,3,%/year,-,Guesstimate,
+electric steam cracker,FOM,2015,3,%/year,2015,Guesstimate,
 electric steam cracker,VOM,2015,180,€/t_HVC,2015,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",
 electric steam cracker,naphtha-input,2015,14.8,MWh_naphtha/t_HVC,-,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",
 electric steam cracker,electricity-input,2015,2.7,MWh_el/t_HVC,-,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",Assuming electrified processing.
@@ -258,10 +258,10 @@ csp-tower,investment,2020,159.96,"EUR/kW_th,dp",2020,ATB CSP data (https://atb.n
 csp-tower,investment,2030,108.37,"EUR/kW_th,dp",2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR."
 csp-tower,investment,2040,99.97,"EUR/kW_th,dp",2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR."
 csp-tower,investment,2050,99.38,"EUR/kW_th,dp",2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR."
-csp-tower,FOM,2020,1,%/year,1,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.
-csp-tower,FOM,2030,1.1,%/year,1.1,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.
-csp-tower,FOM,2040,1.3,%/year,1.3,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.
-csp-tower,FOM,2050,1.4,%/year,1.4,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.
+csp-tower,FOM,2020,1,%/year,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.
+csp-tower,FOM,2030,1.1,%/year,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.
+csp-tower,FOM,2040,1.3,%/year,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.
+csp-tower,FOM,2050,1.4,%/year,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.
 csp-tower,lifetime,2020,30,years,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-
 csp-tower,lifetime,2030,30,years,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-
 csp-tower,lifetime,2040,30,years,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-
@@ -270,10 +270,10 @@ csp-tower TES,investment,2020,21.43,EUR/kWh_th,2020,ATB CSP data (https://atb.nr
 csp-tower TES,investment,2030,14.52,EUR/kWh_th,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR."
 csp-tower TES,investment,2040,13.39,EUR/kWh_th,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR."
 csp-tower TES,investment,2050,13.32,EUR/kWh_th,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR."
-csp-tower TES,FOM,2020,1,%/year,1,see solar-tower.,-
-csp-tower TES,FOM,2030,1.1,%/year,1.1,see solar-tower.,-
-csp-tower TES,FOM,2040,1.3,%/year,1.3,see solar-tower.,-
-csp-tower TES,FOM,2050,1.4,%/year,1.4,see solar-tower.,-
+csp-tower TES,FOM,2020,1,%/year,2020,see solar-tower.,-
+csp-tower TES,FOM,2030,1.1,%/year,2020,see solar-tower.,-
+csp-tower TES,FOM,2040,1.3,%/year,2020,see solar-tower.,-
+csp-tower TES,FOM,2050,1.4,%/year,2020,see solar-tower.,-
 csp-tower TES,lifetime,2020,30,years,2020,see solar-tower.,-
 csp-tower TES,lifetime,2030,30,years,2020,see solar-tower.,-
 csp-tower TES,lifetime,2040,30,years,2020,see solar-tower.,-
@@ -282,10 +282,10 @@ csp-tower power block,investment,2020,1120.57,EUR/kW_e,2020,ATB CSP data (https:
 csp-tower power block,investment,2030,759.17,EUR/kW_e,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR."
 csp-tower power block,investment,2040,700.34,EUR/kW_e,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR."
 csp-tower power block,investment,2050,696.2,EUR/kW_e,2020,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR."
-csp-tower power block,FOM,2020,1,%/year,1,see solar-tower.,-
-csp-tower power block,FOM,2030,1.1,%/year,1.1,see solar-tower.,-
-csp-tower power block,FOM,2040,1.3,%/year,1.3,see solar-tower.,-
-csp-tower power block,FOM,2050,1.4,%/year,1.4,see solar-tower.,-
+csp-tower power block,FOM,2020,1,%/year,2020,see solar-tower.,-
+csp-tower power block,FOM,2030,1.1,%/year,2020,see solar-tower.,-
+csp-tower power block,FOM,2040,1.3,%/year,2020,see solar-tower.,-
+csp-tower power block,FOM,2050,1.4,%/year,2020,see solar-tower.,-
 csp-tower power block,lifetime,2020,30,years,2020,see solar-tower.,-
 csp-tower power block,lifetime,2030,30,years,2020,see solar-tower.,-
 csp-tower power block,lifetime,2040,30,years,2020,see solar-tower.,-
@@ -394,13 +394,13 @@ iron-air battery,FOM,2040,1.1807773334732,%/year,2020,"Form Energy, FormEnergy_E
 iron-air battery,investment,2025,23.45,EUR/kWh,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery,investment,2030,15.61,EUR/kWh,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery,investment,2035,11.79,EUR/kWh,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
-iron-air battery,investment,2040,10.40,EUR/kWh,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
-iron-air battery charge,efficiency,2025,0.70,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
+iron-air battery,investment,2040,10.4,EUR/kWh,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
+iron-air battery charge,efficiency,2025,0.7,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery charge,efficiency,2030,0.71,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery charge,efficiency,2035,0.73,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery charge,efficiency,2040,0.74,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery discharge,efficiency,2025,0.59,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
-iron-air battery discharge,efficiency,2030,0.60,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
+iron-air battery discharge,efficiency,2030,0.6,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery discharge,efficiency,2035,0.62,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery discharge,efficiency,2040,0.63,per unit,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",
 iron-air battery,lifetime,2030,17.5,years,2020,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",

--- a/outputs/costs_2020.csv
+++ b/outputs/costs_2020.csv
@@ -472,11 +472,11 @@ Pumped-Storage-Hydro-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90
 Pumped-Storage-Hydro-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020.0
 Pumped-Storage-Hydro-store,investment,57074.0625,EUR/MWh,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Reservoir Construction & Infrastructure']}",2020.0
 Pumped-Storage-Hydro-store,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,efficiency,0.76,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR,investment,522201.0492,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,lifetime,30.0,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR CC,capture_rate,0.9,EUR/MW_CH4,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",wide range: capture rates betwen 54%-90%,
 SMR CC,efficiency,0.69,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR CC,investment,605753.2171,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
@@ -742,7 +742,7 @@ central water-sourced heat pump,VOM,1.8942,EUR/MWh,"Danish Energy Agency, techno
 central water-sourced heat pump,efficiency,3.78,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Total efficiency , net, annual average",2015.0
 central water-sourced heat pump,investment,1058.2216,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Specific investment",2015.0
 central water-sourced heat pump,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Technical lifetime",2015.0
-clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,investment,69.1286,EUR/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
 coal,CO2 intensity,0.3361,tCO2/MWh_th,Entwicklung der spezifischen Kohlendioxid-Emissionen des deutschen Strommix in den Jahren 1990 - 2018,,
@@ -752,13 +752,13 @@ coal,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 
 coal,fuel,9.5542,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 99 USD/t.",2010.0
 coal,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR).",2023.0
 coal,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023.0
-csp-tower,FOM,1.0,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,1.0
+csp-tower,FOM,1.0,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,2020.0
 csp-tower,investment,159.96,"EUR/kW_th,dp",ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower,lifetime,30.0,years,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-,2020.0
-csp-tower TES,FOM,1.0,%/year,see solar-tower.,-,1.0
+csp-tower TES,FOM,1.0,%/year,see solar-tower.,-,2020.0
 csp-tower TES,investment,21.43,EUR/kWh_th,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower TES,lifetime,30.0,years,see solar-tower.,-,2020.0
-csp-tower power block,FOM,1.0,%/year,see solar-tower.,-,1.0
+csp-tower power block,FOM,1.0,%/year,see solar-tower.,-,2020.0
 csp-tower power block,investment,1120.57,EUR/kW_e,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower power block,lifetime,30.0,years,see solar-tower.,-,2020.0
 decentral CHP,FOM,3.0,%/year,HP, from old pypsa cost assumptions,2015.0
@@ -804,7 +804,7 @@ decentral water tank storage,energy to power ratio,0.15,h,"Danish Energy Agency,
 decentral water tank storage,investment,433.8709,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Specific investment,2015.0
 decentral water tank storage,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Technical lifetime,2015.0
 digestible biomass,fuel,17.0611,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOAGRW1, ENS_Ref for 2040",,2010.0
-digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 digestible biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 digestible biomass to hydrogen,efficiency,0.39,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 digestible biomass to hydrogen,investment,4237.1194,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
@@ -856,7 +856,7 @@ electric boiler steam,VOM,0.8711,EUR/MWh,"Danish Energy Agency, technology_data_
 electric boiler steam,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","310.1 Electric boiler steam  :  Total efficiency, net, annual average",2019.0
 electric boiler steam,investment,80.56,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Nominal investment,2019.0
 electric boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Technical lifetime,2019.0
-electric steam cracker,FOM,3.0,%/year,Guesstimate,,
+electric steam cracker,FOM,3.0,%/year,Guesstimate,,2015.0
 electric steam cracker,VOM,190.4799,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",,2015.0
 electric steam cracker,carbondioxide-output,0.55,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), ",The report also references another source with 0.76 t_CO2/t_HVC,
 electric steam cracker,electricity-input,2.7,MWh_el/t_HVC,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",Assuming electrified processing.,
@@ -870,7 +870,7 @@ electricity grid connection,FOM,2.0,%/year,TODO, from old pypsa cost assumptions
 electricity grid connection,investment,148.151,EUR/kW,DEA, from old pypsa cost assumptions,2015.0
 electricity grid connection,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
 electrobiofuels,C in fuel,0.9245,per unit,Stoichiometric calculation,,
-electrobiofuels,FOM,2.4,%/year,combination of BtL and electrofuels,,
+electrobiofuels,FOM,2.4,%/year,combination of BtL and electrofuels,,2015.0
 electrobiofuels,VOM,5.153,EUR/MWh_th,combination of BtL and electrofuels,,2017.0
 electrobiofuels,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 electrobiofuels,efficiency-biomass,1.3183,per unit,Stoichiometric calculation,,
@@ -978,7 +978,7 @@ methanol-to-kerosene,hydrogen-input,0.0279,MWh_H2/MWh_kerosene,"Concawe (2022): 
 methanol-to-kerosene,investment,307000.0,EUR/MW_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
 methanol-to-kerosene,lifetime,30.0,years,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,
 methanol-to-kerosene,methanol-input,1.0764,MWh_MeOH/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 6.","Assuming LHV 11.94 kWh/kg for kerosene, 5.54 kWh/kg for methanol, 33.3 kWh/kg for hydrogen.",
-methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,
+methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,2015.0
 methanol-to-olefins/aromatics,VOM,31.7466,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", ,2015.0
 methanol-to-olefins/aromatics,carbondioxide-output,0.6107,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 0.4 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 1.13 t_CO2/t_BTX for 15.7 Mt of BTX. The report also references process emissions of 0.55 t_MeOH/t_ethylene+propylene elsewhere. ",
 methanol-to-olefins/aromatics,electricity-input,1.3889,MWh_el/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), page 69",5 GJ/t_HVC ,
@@ -1040,7 +1040,7 @@ ror,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from 
 ror,investment,3412.2266,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
 ror,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
 seawater RO desalination,electricity-input,0.003,MWHh_el/t_H2O,"Caldera et al. (2016): Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",Desalination using SWRO. Assume medium salinity of 35 Practical Salinity Units (PSUs) = 35 kg/m^3.,
-seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2015.0
 seawater desalination,electricity-input,3.0348,kWh/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",,
 seawater desalination,investment,42561.4413,EUR/(m^3-H2O/h),"Caldera et al 2017: Learning Curve for Seawater Reverse Osmosis Desalination Plants: Capital Cost Trend of the Past, Present, and Future (https://doi.org/10.1002/2017WR021402), Table 4.",,2015.0
 seawater desalination,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
@@ -1078,7 +1078,7 @@ solid biomass boiler steam CC,VOM,2.7985,EUR/MWh,"Danish Energy Agency, technolo
 solid biomass boiler steam CC,efficiency,0.89,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019.0
 solid biomass boiler steam CC,investment,622.5091,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019.0
 solid biomass boiler steam CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019.0
-solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 solid biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 solid biomass to hydrogen,efficiency,0.56,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 solid biomass to hydrogen,investment,4237.1194,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0

--- a/outputs/costs_2025.csv
+++ b/outputs/costs_2025.csv
@@ -472,11 +472,11 @@ Pumped-Storage-Hydro-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90
 Pumped-Storage-Hydro-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020.0
 Pumped-Storage-Hydro-store,investment,57074.0625,EUR/MWh,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Reservoir Construction & Infrastructure']}",2020.0
 Pumped-Storage-Hydro-store,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,efficiency,0.76,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR,investment,522201.0492,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,lifetime,30.0,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR CC,capture_rate,0.9,EUR/MW_CH4,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",wide range: capture rates betwen 54%-90%,
 SMR CC,efficiency,0.69,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR CC,investment,605753.2171,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
@@ -742,7 +742,7 @@ central water-sourced heat pump,VOM,1.7884,EUR/MWh,"Danish Energy Agency, techno
 central water-sourced heat pump,efficiency,3.8,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Total efficiency , net, annual average",2015.0
 central water-sourced heat pump,investment,1058.2216,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Specific investment",2015.0
 central water-sourced heat pump,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Technical lifetime",2015.0
-clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,investment,69.1286,EUR/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
 coal,CO2 intensity,0.3361,tCO2/MWh_th,Entwicklung der spezifischen Kohlendioxid-Emissionen des deutschen Strommix in den Jahren 1990 - 2018,,
@@ -752,13 +752,13 @@ coal,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 
 coal,fuel,9.5542,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 99 USD/t.",2010.0
 coal,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR).",2023.0
 coal,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023.0
-csp-tower,FOM,1.05,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,1.0
+csp-tower,FOM,1.05,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,2020.0
 csp-tower,investment,134.165,"EUR/kW_th,dp",ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower,lifetime,30.0,years,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-,2020.0
-csp-tower TES,FOM,1.05,%/year,see solar-tower.,-,1.0
+csp-tower TES,FOM,1.05,%/year,see solar-tower.,-,2020.0
 csp-tower TES,investment,17.975,EUR/kWh_th,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower TES,lifetime,30.0,years,see solar-tower.,-,2020.0
-csp-tower power block,FOM,1.05,%/year,see solar-tower.,-,1.0
+csp-tower power block,FOM,1.05,%/year,see solar-tower.,-,2020.0
 csp-tower power block,investment,939.87,EUR/kW_e,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower power block,lifetime,30.0,years,see solar-tower.,-,2020.0
 decentral CHP,FOM,3.0,%/year,HP, from old pypsa cost assumptions,2015.0
@@ -804,7 +804,7 @@ decentral water tank storage,energy to power ratio,0.15,h,"Danish Energy Agency,
 decentral water tank storage,investment,433.8709,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Specific investment,2015.0
 decentral water tank storage,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Technical lifetime,2015.0
 digestible biomass,fuel,17.0611,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOAGRW1, ENS_Ref for 2040",,2010.0
-digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 digestible biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 digestible biomass to hydrogen,efficiency,0.39,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 digestible biomass to hydrogen,investment,3972.2994,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
@@ -856,7 +856,7 @@ electric boiler steam,VOM,0.8761,EUR/MWh,"Danish Energy Agency, technology_data_
 electric boiler steam,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","310.1 Electric boiler steam  :  Total efficiency, net, annual average",2019.0
 electric boiler steam,investment,75.525,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Nominal investment,2019.0
 electric boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Technical lifetime,2019.0
-electric steam cracker,FOM,3.0,%/year,Guesstimate,,
+electric steam cracker,FOM,3.0,%/year,Guesstimate,,2015.0
 electric steam cracker,VOM,190.4799,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",,2015.0
 electric steam cracker,carbondioxide-output,0.55,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), ",The report also references another source with 0.76 t_CO2/t_HVC,
 electric steam cracker,electricity-input,2.7,MWh_el/t_HVC,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",Assuming electrified processing.,
@@ -870,7 +870,7 @@ electricity grid connection,FOM,2.0,%/year,TODO, from old pypsa cost assumptions
 electricity grid connection,investment,148.151,EUR/kW,DEA, from old pypsa cost assumptions,2015.0
 electricity grid connection,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
 electrobiofuels,C in fuel,0.9257,per unit,Stoichiometric calculation,,
-electrobiofuels,FOM,2.5263,%/year,combination of BtL and electrofuels,,
+electrobiofuels,FOM,2.5263,%/year,combination of BtL and electrofuels,,2015.0
 electrobiofuels,VOM,4.6849,EUR/MWh_th,combination of BtL and electrofuels,,2017.0
 electrobiofuels,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 electrobiofuels,efficiency-biomass,1.32,per unit,Stoichiometric calculation,,
@@ -978,7 +978,7 @@ methanol-to-kerosene,hydrogen-input,0.0279,MWh_H2/MWh_kerosene,"Concawe (2022): 
 methanol-to-kerosene,investment,288000.0,EUR/MW_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
 methanol-to-kerosene,lifetime,30.0,years,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,
 methanol-to-kerosene,methanol-input,1.0764,MWh_MeOH/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 6.","Assuming LHV 11.94 kWh/kg for kerosene, 5.54 kWh/kg for methanol, 33.3 kWh/kg for hydrogen.",
-methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,
+methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,2015.0
 methanol-to-olefins/aromatics,VOM,31.7466,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", ,2015.0
 methanol-to-olefins/aromatics,carbondioxide-output,0.6107,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 0.4 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 1.13 t_CO2/t_BTX for 15.7 Mt of BTX. The report also references process emissions of 0.55 t_MeOH/t_ethylene+propylene elsewhere. ",
 methanol-to-olefins/aromatics,electricity-input,1.3889,MWh_el/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), page 69",5 GJ/t_HVC ,
@@ -1040,7 +1040,7 @@ ror,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from 
 ror,investment,3412.2266,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
 ror,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
 seawater RO desalination,electricity-input,0.003,MWHh_el/t_H2O,"Caldera et al. (2016): Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",Desalination using SWRO. Assume medium salinity of 35 Practical Salinity Units (PSUs) = 35 kg/m^3.,
-seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2015.0
 seawater desalination,electricity-input,3.0348,kWh/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",,
 seawater desalination,investment,39056.5182,EUR/(m^3-H2O/h),"Caldera et al 2017: Learning Curve for Seawater Reverse Osmosis Desalination Plants: Capital Cost Trend of the Past, Present, and Future (https://doi.org/10.1002/2017WR021402), Table 4.",,2015.0
 seawater desalination,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
@@ -1078,7 +1078,7 @@ solid biomass boiler steam CC,VOM,2.8216,EUR/MWh,"Danish Energy Agency, technolo
 solid biomass boiler steam CC,efficiency,0.89,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019.0
 solid biomass boiler steam CC,investment,608.7773,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019.0
 solid biomass boiler steam CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019.0
-solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 solid biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 solid biomass to hydrogen,efficiency,0.56,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 solid biomass to hydrogen,investment,3972.2994,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0

--- a/outputs/costs_2030.csv
+++ b/outputs/costs_2030.csv
@@ -1,1103 +1,1103 @@
 technology,parameter,value,unit,source,further description,currency_year
-Ammonia cracker,FOM,4.3,%/year,"Ishimoto et al. (2020): 10.1016/j.ijhydene.2020.09.017 , table 7.","Estimated based on Labour cost rate, Maintenance cost rate, Insurance rate, Admin. cost rate and Chemical & other consumables cost rate.",2015.0
+Ammonia cracker,FOM,4.3,%/year,"Ishimoto et al. (2020): 10.1016/j.ijhydene.2020.09.017 , table 7.","Estimated based on Labour cost rate, Maintenance cost rate, Insurance rate, Admin. cost rate and Chemical & other consumables cost rate.",2015
 Ammonia cracker,ammonia-input,1.46,MWh_NH3/MWh_H2,"ENGIE et al (2020): Ammonia to Green Hydrogen Feasibility Study (https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/880826/HS420_-_Ecuity_-_Ammonia_to_Green_Hydrogen.pdf), Fig. 10.",Assuming a integrated 200t/d cracking and purification facility. Electricity demand (316 MWh per 2186 MWh_LHV H2 output) is assumed to also be ammonia LHV input which seems a fair assumption as the facility has options for a higher degree of integration according to the report).,
 Ammonia cracker,investment,1123945.3807,EUR/MW_H2,"Ishimoto et al. (2020): 10.1016/j.ijhydene.2020.09.017 , table 6.","Calculated. For a small (200 t_NH3/d input) facility. Base cost for facility: 51 MEUR at capacity 20 000m^3_NH3/h = 339 t_NH3/d input. Cost scaling exponent 0.67. Ammonia density 0.7069 kg/m^3. Conversion efficiency of cracker: 0.685. Ammonia LHV: 5.167 MWh/t_NH3.; and
-Calculated. For a large (2500 t_NH3/d input) facility. Base cost for facility: 51 MEUR at capacity 20 000m^3_NH3/h = 339 t_NH3/d input. Cost scaling exponent 0.67. Ammonia density 0.7069 kg/m^3. Conversion efficiency of cracker: 0.685. Ammonia LHV: 5.167 MWh/t_NH3.",2015.0
-Ammonia cracker,lifetime,25.0,years,"Ishimoto et al. (2020): 10.1016/j.ijhydene.2020.09.017 , table 7.",,2015.0
-BEV Bus city,FOM,0.0003,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022.0
-BEV Bus city,Motor size,346.5517,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022.0
-BEV Bus city,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022.0
-BEV Bus city,efficiency,0.8585,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022.0
-BEV Bus city,investment,222485.6452,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022.0
-BEV Bus city,lifetime,12.0,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022.0
-BEV Coach,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022.0
-BEV Coach,Motor size,358.6207,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022.0
-BEV Coach,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022.0
-BEV Coach,efficiency,0.8446,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022.0
-BEV Coach,investment,303025.4488,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022.0
-BEV Coach,lifetime,12.0,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022.0
-BEV Truck Semi-Trailer max 50 tons,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022.0
-BEV Truck Semi-Trailer max 50 tons,Motor size,555.1724,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022.0
-BEV Truck Semi-Trailer max 50 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022.0
-BEV Truck Semi-Trailer max 50 tons,efficiency,1.3936,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022.0
-BEV Truck Semi-Trailer max 50 tons,investment,151213.8954,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022.0
-BEV Truck Semi-Trailer max 50 tons,lifetime,10.5,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022.0
-BEV Truck Solo max 26 tons,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022.0
-BEV Truck Solo max 26 tons,Motor size,382.7586,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022.0
-BEV Truck Solo max 26 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022.0
-BEV Truck Solo max 26 tons,efficiency,0.8755,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022.0
-BEV Truck Solo max 26 tons,investment,282418.6749,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022.0
-BEV Truck Solo max 26 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022.0
-BEV Truck Trailer max 56 tons,FOM,0.0003,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022.0
-BEV Truck Trailer max 56 tons,Motor size,710.3448,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022.0
-BEV Truck Trailer max 56 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022.0
-BEV Truck Trailer max 56 tons,efficiency,1.5446,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022.0
-BEV Truck Trailer max 56 tons,investment,167722.8037,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022.0
-BEV Truck Trailer max 56 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022.0
-Battery electric (passenger cars),FOM,0.9,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (passenger cars),2020.0
-Battery electric (passenger cars),efficiency,0.68,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (passenger cars),2020.0
-Battery electric (passenger cars),investment,24624.0,EUR/PKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (passenger cars),2020.0
-Battery electric (passenger cars),lifetime,15.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (passenger cars),2020.0
-Battery electric (trucks),FOM,15.0,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (trucks),2020.0
-Battery electric (trucks),investment,136400.0,EUR/LKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (trucks),2020.0
-Battery electric (trucks),lifetime,15.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (trucks),2020.0
+Calculated. For a large (2500 t_NH3/d input) facility. Base cost for facility: 51 MEUR at capacity 20 000m^3_NH3/h = 339 t_NH3/d input. Cost scaling exponent 0.67. Ammonia density 0.7069 kg/m^3. Conversion efficiency of cracker: 0.685. Ammonia LHV: 5.167 MWh/t_NH3.",2015
+Ammonia cracker,lifetime,25,years,"Ishimoto et al. (2020): 10.1016/j.ijhydene.2020.09.017 , table 7.",,2015
+BEV Bus city,FOM,0.0003,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022
+BEV Bus city,Motor size,346.5517,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022
+BEV Bus city,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022
+BEV Bus city,efficiency,0.8585,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022
+BEV Bus city,investment,222485.6452,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022
+BEV Bus city,lifetime,12,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B1,2022
+BEV Coach,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022
+BEV Coach,Motor size,358.6207,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022
+BEV Coach,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022
+BEV Coach,efficiency,0.8446,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022
+BEV Coach,investment,303025.4488,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022
+BEV Coach,lifetime,12,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV B2,2022
+BEV Truck Semi-Trailer max 50 tons,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022
+BEV Truck Semi-Trailer max 50 tons,Motor size,555.1724,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022
+BEV Truck Semi-Trailer max 50 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022
+BEV Truck Semi-Trailer max 50 tons,efficiency,1.3936,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022
+BEV Truck Semi-Trailer max 50 tons,investment,151213.8954,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022
+BEV Truck Semi-Trailer max 50 tons,lifetime,10.5,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L3,2022
+BEV Truck Solo max 26 tons,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022
+BEV Truck Solo max 26 tons,Motor size,382.7586,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022
+BEV Truck Solo max 26 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022
+BEV Truck Solo max 26 tons,efficiency,0.8755,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022
+BEV Truck Solo max 26 tons,investment,282418.6749,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022
+BEV Truck Solo max 26 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L1,2022
+BEV Truck Trailer max 56 tons,FOM,0.0003,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022
+BEV Truck Trailer max 56 tons,Motor size,710.3448,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022
+BEV Truck Trailer max 56 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022
+BEV Truck Trailer max 56 tons,efficiency,1.5446,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022
+BEV Truck Trailer max 56 tons,investment,167722.8037,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022
+BEV Truck Trailer max 56 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",BEV L2,2022
+Battery electric (passenger cars),FOM,0.9,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (passenger cars),2020
+Battery electric (passenger cars),efficiency,0.68,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (passenger cars),2020
+Battery electric (passenger cars),investment,24624,EUR/PKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (passenger cars),2020
+Battery electric (passenger cars),lifetime,15,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (passenger cars),2020
+Battery electric (trucks),FOM,15,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (trucks),2020
+Battery electric (trucks),investment,136400,EUR/LKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (trucks),2020
+Battery electric (trucks),lifetime,15,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Battery electric (trucks),2020
 BioSNG,C in fuel,0.3402,per unit,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
 BioSNG,C stored,0.6598,per unit,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
 BioSNG,CO2 stored,0.2419,tCO2/MWh_th,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
-BioSNG,FOM,1.6375,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","84 Gasif. CFB, Bio-SNG:  Fixed O&M",2020.0
-BioSNG,VOM,1.8078,EUR/MWh_th,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","84 Gasif. CFB, Bio-SNG:  Variable O&M",2020.0
+BioSNG,FOM,1.6375,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","84 Gasif. CFB, Bio-SNG:  Fixed O&M",2020
+BioSNG,VOM,1.8078,EUR/MWh_th,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","84 Gasif. CFB, Bio-SNG:  Variable O&M",2020
 BioSNG,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
-BioSNG,efficiency,0.63,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","84 Gasif. CFB, Bio-SNG:  Bio SNG Output",2020.0
-BioSNG,investment,1701.44,EUR/kW_th,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","84 Gasif. CFB, Bio-SNG:  Specific investment",2020.0
-BioSNG,lifetime,25.0,years,TODO,"84 Gasif. CFB, Bio-SNG:  Technical lifetime",2020.0
+BioSNG,efficiency,0.63,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","84 Gasif. CFB, Bio-SNG:  Bio SNG Output",2020
+BioSNG,investment,1701.44,EUR/kW_th,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","84 Gasif. CFB, Bio-SNG:  Specific investment",2020
+BioSNG,lifetime,25,years,TODO,"84 Gasif. CFB, Bio-SNG:  Technical lifetime",2020
 BtL,C in fuel,0.2688,per unit,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
 BtL,C stored,0.7312,per unit,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
 BtL,CO2 stored,0.2681,tCO2/MWh_th,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
-BtL,FOM,2.6667,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","85 Gasif. Ent. Flow FT, liq fu :  Fixed O&M",2020.0
-BtL,VOM,1.1299,EUR/MWh_FT,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","85 Gasif. Ent. Flow FT, liq fu :  Variable O&M",2020.0
+BtL,FOM,2.6667,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","85 Gasif. Ent. Flow FT, liq fu :  Fixed O&M",2020
+BtL,VOM,1.1299,EUR/MWh_FT,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","85 Gasif. Ent. Flow FT, liq fu :  Variable O&M",2020
 BtL,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
-BtL,efficiency,0.3833,per unit,doi:10.1016/j.enpol.2017.05.013,"85 Gasif. Ent. Flow FT, liq fu :  Electricity Output",2020.0
-BtL,investment,3118.4333,EUR/kW_th,doi:10.1016/j.enpol.2017.05.013,"85 Gasif. Ent. Flow FT, liq fu :  Specific investment",2017.0
-BtL,lifetime,25.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","85 Gasif. Ent. Flow FT, liq fu :  Technical lifetime",2020.0
-CCGT,FOM,3.3494,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Fixed O&M",2015.0
-CCGT,VOM,4.4445,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Variable O&M",2015.0
-CCGT,c_b,2.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Cb coefficient",2015.0
-CCGT,c_v,0.15,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Cv coefficient",2015.0
-CCGT,efficiency,0.58,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Electricity efficiency, annual average",2015.0
-CCGT,investment,878.324,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Nominal investment",2015.0
-CCGT,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Technical lifetime",2015.0
-CH4 (g) fill compressor station,FOM,1.7,%/year,Assume same as for H2 (g) fill compressor station.,-,2020.0
-CH4 (g) fill compressor station,investment,1654.96,EUR/MW_CH4,"Guesstimate, based on H2 (g) pipeline and fill compressor station cost.","Assume same ratio as between H2 (g) pipeline and fill compressor station, i.e. 1:19 , due to a lack of reliable numbers.",2020.0
-CH4 (g) fill compressor station,lifetime,20.0,years,Assume same as for H2 (g) fill compressor station.,-,2020.0
-CH4 (g) pipeline,FOM,1.5,%/year,Assume same as for H2 (g) pipeline in 2050 (CH4 pipeline as mature technology).,"Due to lack of numbers, use comparable H2 pipeline assumptions.",2020.0
-CH4 (g) pipeline,electricity-input,0.01,MW_e/1000km/MW_CH4,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: 112 6 gas Main distri line.","Assumption for gas pipeline >100MW, 0.1% per station and spacing of 100km yields 1%/1000km. Electric compression.",2015.0
-CH4 (g) pipeline,investment,87.22,EUR/MW/km,Guesstimate.,"Based on Arab Gas Pipeline: https://en.wikipedia.org/wiki/Arab_Gas_Pipeline: cost = 1.2e9 $-US (year = ?), capacity=10.3e9 m^3/a NG, l=1200km, NG-LHV=39MJ/m^3*90% (also Wikipedia estimate from here https://en.wikipedia.org/wiki/Heat_of_combustion). Presumed to include booster station cost.",2020.0
-CH4 (g) pipeline,lifetime,50.0,years,Assume same as for H2 (g) pipeline in 2050 (CH4 pipeline as mature technology).,"Due to lack of numbers, use comparable H2 pipeline assumptions.",2020.0
-CH4 (g) submarine pipeline,FOM,3.0,%/year,"d’Amore-Domenech et al (2021): 10.1016/j.apenergy.2021.116625 , supplementary material.",-,2015.0
-CH4 (g) submarine pipeline,electricity-input,0.01,MW_e/1000km/MW_CH4,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: 112 6 gas Main distri line.","Assumption for gas pipeline >100MW, 0.1% per station and spacing of 100km yields 1%/1000km. Electric compression.",2015.0
-CH4 (g) submarine pipeline,investment,119.3173,EUR/MW/km,Kaiser (2017): 10.1016/j.marpol.2017.05.003 .,"Based on Gulfstream pipeline costs (430 mi long pipeline for natural gas in deep/shallow waters) of 2.72e6 USD/mi and 1.31 bn ft^3/d capacity (36 in diameter), LHV of methane 13.8888 MWh/t and density of 0.657 kg/m^3 and 1.17 USD:1EUR conversion rate = 102.4 EUR/MW/km. Number is without booster station cost. Estimation of additional cost for booster stations based on H2 (g) pipeline numbers from Guidehouse (2020): European Hydrogen Backbone report and Danish Energy Agency (2021): Technology Data for Energy Transport, were booster stations make ca. 6% of pipeline cost; here add additional 10% for booster stations as they need to be constructed submerged or on plattforms. (102.4*1.1).",2014.0
-CH4 (g) submarine pipeline,lifetime,30.0,years,"d’Amore-Domenech et al (2021): 10.1016/j.apenergy.2021.116625 , supplementary material.",-,2015.0
-CH4 (l) transport ship,FOM,3.5,%/year,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2015.0
-CH4 (l) transport ship,capacity,58300.0,t_CH4,"Calculated, based on Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",based on 138 000 m^3 capacity and LNG density of 0.4226 t/m^3 .,2015.0
-CH4 (l) transport ship,investment,159791465.6831,EUR,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2015.0
-CH4 (l) transport ship,lifetime,25.0,years,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2015.0
-CH4 evaporation,FOM,3.5,%/year,"Lochner and Bothe (2009): https://doi.org/10.1016/j.enpol.2008.12.012 and Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2005.0
-CH4 evaporation,investment,91.1101,EUR/kW_CH4,"Calculated, based on Lochner and Bothe (2009): https://doi.org/10.1016/j.enpol.2008.12.012 and Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306","based on 100 MUSD-2005/(1 bcm/a), 1 bcm = 10.6 TWh, currency exchange rate: 1.15 USD=1 EUR.",2005.0
-CH4 evaporation,lifetime,30.0,years,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2005.0
-CH4 liquefaction,FOM,3.5,%/year,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2005.0
+BtL,efficiency,0.3833,per unit,doi:10.1016/j.enpol.2017.05.013,"85 Gasif. Ent. Flow FT, liq fu :  Electricity Output",2020
+BtL,investment,3118.4333,EUR/kW_th,doi:10.1016/j.enpol.2017.05.013,"85 Gasif. Ent. Flow FT, liq fu :  Specific investment",2017
+BtL,lifetime,25,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","85 Gasif. Ent. Flow FT, liq fu :  Technical lifetime",2020
+CCGT,FOM,3.3494,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Fixed O&M",2015
+CCGT,VOM,4.4445,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Variable O&M",2015
+CCGT,c_b,2,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Cb coefficient",2015
+CCGT,c_v,0.15,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Cv coefficient",2015
+CCGT,efficiency,0.58,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Electricity efficiency, annual average",2015
+CCGT,investment,878.324,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Nominal investment",2015
+CCGT,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","05 Gas turb. CC, steam extract.:  Technical lifetime",2015
+CH4 (g) fill compressor station,FOM,1.7,%/year,Assume same as for H2 (g) fill compressor station.,-,2020
+CH4 (g) fill compressor station,investment,1654.96,EUR/MW_CH4,"Guesstimate, based on H2 (g) pipeline and fill compressor station cost.","Assume same ratio as between H2 (g) pipeline and fill compressor station, i.e. 1:19 , due to a lack of reliable numbers.",2020
+CH4 (g) fill compressor station,lifetime,20,years,Assume same as for H2 (g) fill compressor station.,-,2020
+CH4 (g) pipeline,FOM,1.5,%/year,Assume same as for H2 (g) pipeline in 2050 (CH4 pipeline as mature technology).,"Due to lack of numbers, use comparable H2 pipeline assumptions.",2020
+CH4 (g) pipeline,electricity-input,0.01,MW_e/1000km/MW_CH4,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: 112 6 gas Main distri line.","Assumption for gas pipeline >100MW, 0.1% per station and spacing of 100km yields 1%/1000km. Electric compression.",2015
+CH4 (g) pipeline,investment,87.22,EUR/MW/km,Guesstimate.,"Based on Arab Gas Pipeline: https://en.wikipedia.org/wiki/Arab_Gas_Pipeline: cost = 1.2e9 $-US (year = ?), capacity=10.3e9 m^3/a NG, l=1200km, NG-LHV=39MJ/m^3*90% (also Wikipedia estimate from here https://en.wikipedia.org/wiki/Heat_of_combustion). Presumed to include booster station cost.",2020
+CH4 (g) pipeline,lifetime,50,years,Assume same as for H2 (g) pipeline in 2050 (CH4 pipeline as mature technology).,"Due to lack of numbers, use comparable H2 pipeline assumptions.",2020
+CH4 (g) submarine pipeline,FOM,3,%/year,"d’Amore-Domenech et al (2021): 10.1016/j.apenergy.2021.116625 , supplementary material.",-,2015
+CH4 (g) submarine pipeline,electricity-input,0.01,MW_e/1000km/MW_CH4,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: 112 6 gas Main distri line.","Assumption for gas pipeline >100MW, 0.1% per station and spacing of 100km yields 1%/1000km. Electric compression.",2015
+CH4 (g) submarine pipeline,investment,119.3173,EUR/MW/km,Kaiser (2017): 10.1016/j.marpol.2017.05.003 .,"Based on Gulfstream pipeline costs (430 mi long pipeline for natural gas in deep/shallow waters) of 2.72e6 USD/mi and 1.31 bn ft^3/d capacity (36 in diameter), LHV of methane 13.8888 MWh/t and density of 0.657 kg/m^3 and 1.17 USD:1EUR conversion rate = 102.4 EUR/MW/km. Number is without booster station cost. Estimation of additional cost for booster stations based on H2 (g) pipeline numbers from Guidehouse (2020): European Hydrogen Backbone report and Danish Energy Agency (2021): Technology Data for Energy Transport, were booster stations make ca. 6% of pipeline cost; here add additional 10% for booster stations as they need to be constructed submerged or on plattforms. (102.4*1.1).",2014
+CH4 (g) submarine pipeline,lifetime,30,years,"d’Amore-Domenech et al (2021): 10.1016/j.apenergy.2021.116625 , supplementary material.",-,2015
+CH4 (l) transport ship,FOM,3.5,%/year,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2015
+CH4 (l) transport ship,capacity,58300,t_CH4,"Calculated, based on Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",based on 138 000 m^3 capacity and LNG density of 0.4226 t/m^3 .,2015
+CH4 (l) transport ship,investment,159791465.6831,EUR,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2015
+CH4 (l) transport ship,lifetime,25,years,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2015
+CH4 evaporation,FOM,3.5,%/year,"Lochner and Bothe (2009): https://doi.org/10.1016/j.enpol.2008.12.012 and Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2005
+CH4 evaporation,investment,91.1101,EUR/kW_CH4,"Calculated, based on Lochner and Bothe (2009): https://doi.org/10.1016/j.enpol.2008.12.012 and Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306","based on 100 MUSD-2005/(1 bcm/a), 1 bcm = 10.6 TWh, currency exchange rate: 1.15 USD=1 EUR.",2005
+CH4 evaporation,lifetime,30,years,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2005
+CH4 liquefaction,FOM,3.5,%/year,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2005
 CH4 liquefaction,electricity-input,0.036,MWh_el/MWh_CH4,"Pospíšil et al. (2019): Energy demand of liquefaction and regasification of natural gas and the potential of LNG for operative thermal energy storage (https://doi.org/10.1016/j.rser.2018.09.027), Table 2 and Table 3. alternative source 2: https://encyclopedia.airliquide.com/methane (accessed 2021-02-10).","Assuming 0.5 MWh/t_CH4 for refigeration cycle based on Table 2 of source; cleaning of gas presumed unnecessary as it should be nearly pure CH4 (=SNG). Assuming energy required is only electricity which is for Table 3 in the source provided with efficiencies of ~50% of LHV, making the numbers consistent with the numbers in Table 2.",
-CH4 liquefaction,investment,241.443,EUR/kW_CH4,"Calculated, based on Lochner and Bothe (2009): https://doi.org/10.1016/j.enpol.2008.12.012 and Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306","based on 265 MUSD-2005/(1 bcm/a), 1 bcm = 10.6 TWh, currency exchange rate: 1.15 USD=1 EUR.",2005.0
-CH4 liquefaction,lifetime,25.0,years,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2005.0
-CH4 liquefaction,methane-input,1.0,MWh_CH4/MWh_CH4,"Pospíšil et al. (2019): Energy demand of liquefaction and regasification of natural gas and the potential of LNG for operative thermal energy storage (https://doi.org/10.1016/j.rser.2018.09.027), Table 2 and Table 3. alternative source 2: https://encyclopedia.airliquide.com/methane (accessed 2021-02-10).","For refrigeration cycle, cleaning of gas presumed unnecessary as it should be nearly pure CH4 (=SNG). Assuming energy required is only electricity which is for Table 3 in the source provided with efficiencies of ~50% of LHV, making the numbers consistent with the numbers in Table 2.",
-CO2 liquefaction,FOM,5.0,%/year,Mitsubish Heavy Industries Ltd. and IEA (2004): https://ieaghg.org/docs/General_Docs/Reports/PH4-30%20Ship%20Transport.pdf .,,2004.0
-CO2 liquefaction,carbondioxide-input,1.0,t_CO2/t_CO2,Mitsubish Heavy Industries Ltd. and IEA (2004): https://ieaghg.org/docs/General_Docs/Reports/PH4-30%20Ship%20Transport.pdf .,"Assuming a pure, humid, low-pressure input stream. Neglecting possible gross-effects of CO2 which might be cycled for the cooling process.",
+CH4 liquefaction,investment,241.443,EUR/kW_CH4,"Calculated, based on Lochner and Bothe (2009): https://doi.org/10.1016/j.enpol.2008.12.012 and Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306","based on 265 MUSD-2005/(1 bcm/a), 1 bcm = 10.6 TWh, currency exchange rate: 1.15 USD=1 EUR.",2005
+CH4 liquefaction,lifetime,25,years,"Fasihi et al 2017, table 1, https://www.mdpi.com/2071-1050/9/2/306",,2005
+CH4 liquefaction,methane-input,1,MWh_CH4/MWh_CH4,"Pospíšil et al. (2019): Energy demand of liquefaction and regasification of natural gas and the potential of LNG for operative thermal energy storage (https://doi.org/10.1016/j.rser.2018.09.027), Table 2 and Table 3. alternative source 2: https://encyclopedia.airliquide.com/methane (accessed 2021-02-10).","For refrigeration cycle, cleaning of gas presumed unnecessary as it should be nearly pure CH4 (=SNG). Assuming energy required is only electricity which is for Table 3 in the source provided with efficiencies of ~50% of LHV, making the numbers consistent with the numbers in Table 2.",
+CO2 liquefaction,FOM,5,%/year,Mitsubish Heavy Industries Ltd. and IEA (2004): https://ieaghg.org/docs/General_Docs/Reports/PH4-30%20Ship%20Transport.pdf .,,2004
+CO2 liquefaction,carbondioxide-input,1,t_CO2/t_CO2,Mitsubish Heavy Industries Ltd. and IEA (2004): https://ieaghg.org/docs/General_Docs/Reports/PH4-30%20Ship%20Transport.pdf .,"Assuming a pure, humid, low-pressure input stream. Neglecting possible gross-effects of CO2 which might be cycled for the cooling process.",
 CO2 liquefaction,electricity-input,0.123,MWh_el/t_CO2,Mitsubish Heavy Industries Ltd. and IEA (2004): https://ieaghg.org/docs/General_Docs/Reports/PH4-30%20Ship%20Transport.pdf .,,
 CO2 liquefaction,heat-input,0.0067,MWh_th/t_CO2,Mitsubish Heavy Industries Ltd. and IEA (2004): https://ieaghg.org/docs/General_Docs/Reports/PH4-30%20Ship%20Transport.pdf .,For drying purposes.,
-CO2 liquefaction,investment,16.7226,EUR/t_CO2/h,Mitsubish Heavy Industries Ltd. and IEA (2004): https://ieaghg.org/docs/General_Docs/Reports/PH4-30%20Ship%20Transport.pdf .,"Plant capacity of 20 kt CO2 / d and an uptime of 85%. For a high purity, humid, low pressure input stream, includes drying and compression necessary for liquefaction.",2004.0
-CO2 liquefaction,lifetime,25.0,years,"Guesstimate, based on CH4 liquefaction.",,2004.0
-CO2 pipeline,FOM,0.9,%/year,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",,2015.0
-CO2 pipeline,investment,2116.4433,EUR/(tCO2/h)/km,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",Assuming the 120-500 t CO2/h range that is based on cost of a 12 inch onshore pipeline.,2015.0
-CO2 pipeline,lifetime,50.0,years,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",,2015.0
-CO2 storage tank,FOM,1.0,%/year,"Lauri et al. 2014: doi: 10.1016/j.egypro.2014.11.297, pg. 2746 .","Assuming a 3000m^3 pressurised steel cylinder tanks and a CO2 density of 1100 kg/m^3 (close to triple point at -56.6°C and 5.2 bar with max density of 1200kg/m^3 ). Lauri et al. report costs 3x higher per m^3 for steel tanks, which are consistent with other sources. The numbers reported are in rather difficult to pinpoint as systems can greatly vary.",2013.0
-CO2 storage tank,investment,2584.3462,EUR/t_CO2,"Lauri et al. 2014: doi: 10.1016/j.egypro.2014.11.297, Table 3.","Assuming a 3000m^3 pressurised steel cylinder tanks and a CO2 density of 1100 kg/m^3 (close to triple point at -56.6°C and 5.2 bar with max density of 1200kg/m^3 ). Lauri et al. report costs 3x higher per m^3 for steel tanks, which are consistent with other sources. The numbers reported are in rather difficult to pinpoint as systems can greatly vary.",2013.0
-CO2 storage tank,lifetime,25.0,years,"Lauri et al. 2014: doi: 10.1016/j.egypro.2014.11.297, pg. 2746 .","Assuming a 3000m^3 pressurised steel cylinder tanks and a CO2 density of 1100 kg/m^3 (close to triple point at -56.6°C and 5.2 bar with max density of 1200kg/m^3 ). Lauri et al. report costs 3x higher per m^3 for steel tanks, which are consistent with other sources. The numbers reported are in rather difficult to pinpoint as systems can greatly vary.",2013.0
-CO2 submarine pipeline,FOM,0.5,%/year,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",,2015.0
-CO2 submarine pipeline,investment,4232.8865,EUR/(tCO2/h)/km,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",Assuming the 120-500 t CO2/h range that is based on cost of a 12 inch offshore pipeline.,2015.0
-Charging infrastructure fast (purely) battery electric vehicles passenger cars,FOM,1.6,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fast (purely) battery electric vehicles passenger cars,2020.0
-Charging infrastructure fast (purely) battery electric vehicles passenger cars,investment,448894.0,EUR/Ladesï¿½ule,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fast (purely) battery electric vehicles passenger cars,2020.0
-Charging infrastructure fast (purely) battery electric vehicles passenger cars,lifetime,30.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fast (purely) battery electric vehicles passenger cars,2020.0
-Charging infrastructure fuel cell vehicles passenger cars,FOM,2.2,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles passenger cars,2020.0
-Charging infrastructure fuel cell vehicles passenger cars,investment,1787894.0,EUR/Ladesï¿½ule,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles passenger cars,2020.0
-Charging infrastructure fuel cell vehicles passenger cars,lifetime,30.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles passenger cars,2020.0
-Charging infrastructure fuel cell vehicles trucks,FOM,2.2,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles trucks,2020.0
-Charging infrastructure fuel cell vehicles trucks,investment,1787894.0,EUR/Ladesï¿½ule,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles trucks,2020.0
-Charging infrastructure fuel cell vehicles trucks,lifetime,30.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles trucks,2020.0
-Charging infrastructure slow (purely) battery electric vehicles passenger cars,FOM,1.8,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure slow (purely) battery electric vehicles passenger cars,2020.0
-Charging infrastructure slow (purely) battery electric vehicles passenger cars,investment,1005.0,EUR/Ladesï¿½ule,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure slow (purely) battery electric vehicles passenger cars,2020.0
-Charging infrastructure slow (purely) battery electric vehicles passenger cars,lifetime,30.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure slow (purely) battery electric vehicles passenger cars,2020.0
-Compressed-Air-Adiabatic-bicharger,FOM,0.9265,%/year,"Viswanathan_2022, p.64 (p.86) Figure 4.14","{'carrier': ['elec', 'pair', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Compressed-Air-Adiabatic-bicharger,efficiency,0.7211,per unit,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'pair', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level 0.52^0.5']}",2020.0
-Compressed-Air-Adiabatic-bicharger,investment,946180.9426,EUR/MW,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'pair', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Turbine Compressor BOP EPC Management']}",2020.0
-Compressed-Air-Adiabatic-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'pair', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Compressed-Air-Adiabatic-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB 4.5.2.1 Fixed O&M p.62 (p.84)","{'carrier': ['pair'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020.0
-Compressed-Air-Adiabatic-store,investment,5448.7894,EUR/MWh,"Viswanathan_2022, p.64 (p.86)","{'carrier': ['pair'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Cavern Storage']}",2020.0
-Compressed-Air-Adiabatic-store,lifetime,60.0,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['pair'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Concrete-charger,FOM,1.075,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'concrete'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020.0
-Concrete-charger,efficiency,0.99,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'concrete'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020.0
-Concrete-charger,investment,144192.2682,EUR/MW,"Georgiou_2018, Guesstimate that charge is 20% of capital costs of power components for sensible thermal storage","{'carrier': ['elec', 'concrete'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020.0
-Concrete-charger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'concrete'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Concrete-discharger,FOM,0.2688,%/year,"Viswanathan_2022, NULL","{'carrier': ['concrete', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020.0
-Concrete-discharger,efficiency,0.4343,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['concrete', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020.0
-Concrete-discharger,investment,576769.073,EUR/MW,"Georgiou_2018, Guesstimate that charge is 80% of capital costs of power components for sensible thermal storage","{'carrier': ['concrete', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020.0
-Concrete-discharger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['concrete', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Concrete-store,FOM,0.3308,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['concrete'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020.0
-Concrete-store,investment,24044.2324,EUR/MWh,"Viswanathan_2022, p.98 (p.120)","{'carrier': ['concrete'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['SB and BOS 0.85 of 2021 value']}",2020.0
-Concrete-store,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['concrete'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-"Container feeder, ammonia",efficiency,0.7754,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, ammonia",2023.0
-"Container feeder, ammonia",investment,38462833.2276,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, ammonia",2023.0
-"Container feeder, ammonia",lifetime,30.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, ammonia",2023.0
-"Container feeder, diesel",efficiency,0.7718,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, diesel",2023.0
-"Container feeder, diesel",investment,34966212.0251,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, diesel",2023.0
-"Container feeder, diesel",lifetime,30.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, diesel",2023.0
-"Container feeder, methanol",efficiency,0.7711,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, methanol",2023.0
-"Container feeder, methanol",investment,36802136.8043,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, methanol",2023.0
-"Container feeder, methanol",lifetime,30.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, methanol",2023.0
-"Container, ammonia",efficiency,1.7094,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, ammonia",2023.0
-"Container, ammonia",investment,131618242.0136,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, ammonia",2023.0
-"Container, ammonia",lifetime,31.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, ammonia",2023.0
-"Container, diesel",efficiency,1.6399,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, diesel",2023.0
-"Container, diesel",investment,119652947.2851,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, diesel",2023.0
-"Container, diesel",lifetime,32.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, diesel",2023.0
-"Container, methanol",efficiency,1.7001,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, methanol",2023.0
-"Container, methanol",investment,125635594.6493,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, methanol",2023.0
-"Container, methanol",lifetime,32.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, methanol",2023.0
-Diesel Bus city,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022.0
-Diesel Bus city,Motor size,250.0,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022.0
-Diesel Bus city,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022.0
-Diesel Bus city,efficiency,2.0824,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022.0
-Diesel Bus city,investment,150756.2732,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022.0
-Diesel Bus city,lifetime,12.0,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022.0
-Diesel Coach,FOM,0.0003,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022.0
-Diesel Coach,Motor size,350.0,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022.0
-Diesel Coach,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022.0
-Diesel Coach,efficiency,2.2009,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022.0
-Diesel Coach,investment,231296.0768,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022.0
-Diesel Coach,lifetime,12.0,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022.0
-Diesel Truck Semi-Trailer max 50 tons,FOM,0.0005,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022.0
-Diesel Truck Semi-Trailer max 50 tons,Motor size,380.0,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022.0
-Diesel Truck Semi-Trailer max 50 tons,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022.0
-Diesel Truck Semi-Trailer max 50 tons,efficiency,3.2963,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022.0
-Diesel Truck Semi-Trailer max 50 tons,investment,142012.114,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022.0
-Diesel Truck Semi-Trailer max 50 tons,lifetime,10.5,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022.0
-Diesel Truck Solo max 26 tons,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022.0
-Diesel Truck Solo max 26 tons,Motor size,254.1379,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022.0
-Diesel Truck Solo max 26 tons,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022.0
-Diesel Truck Solo max 26 tons,efficiency,2.1867,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022.0
-Diesel Truck Solo max 26 tons,investment,155444.0931,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022.0
-Diesel Truck Solo max 26 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022.0
-Diesel Truck Trailer max 56 tons,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022.0
-Diesel Truck Trailer max 56 tons,Motor size,382.3529,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022.0
-Diesel Truck Trailer max 56 tons,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022.0
-Diesel Truck Trailer max 56 tons,efficiency,3.3031,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022.0
-Diesel Truck Trailer max 56 tons,investment,177515.1425,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022.0
-Diesel Truck Trailer max 56 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022.0
-FCV Bus city,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022.0
-FCV Bus city,Motor size,390.6897,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022.0
-FCV Bus city,VOM,0.0979,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022.0
-FCV Bus city,efficiency,1.5899,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022.0
-FCV Bus city,investment,323056.5642,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022.0
-FCV Bus city,lifetime,12.0,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022.0
-FCV Coach,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022.0
-FCV Coach,Motor size,390.6897,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022.0
-FCV Coach,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022.0
-FCV Coach,efficiency,1.5761,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022.0
-FCV Coach,investment,356840.1722,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022.0
-FCV Coach,lifetime,12.0,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022.0
-FCV Truck Semi-Trailer max 50 tons,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022.0
-FCV Truck Semi-Trailer max 50 tons,Motor size,513.7931,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022.0
-FCV Truck Semi-Trailer max 50 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022.0
-FCV Truck Semi-Trailer max 50 tons,efficiency,2.548,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022.0
-FCV Truck Semi-Trailer max 50 tons,investment,139809.9795,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022.0
-FCV Truck Semi-Trailer max 50 tons,lifetime,10.5,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022.0
-FCV Truck Solo max 26 tons,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022.0
-FCV Truck Solo max 26 tons,Motor size,381.0345,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022.0
-FCV Truck Solo max 26 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022.0
-FCV Truck Solo max 26 tons,efficiency,1.7064,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022.0
-FCV Truck Solo max 26 tons,investment,255992.8427,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022.0
-FCV Truck Solo max 26 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022.0
-FCV Truck Trailer max 56 tons,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022.0
-FCV Truck Trailer max 56 tons,Motor size,381.0345,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022.0
-FCV Truck Trailer max 56 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022.0
-FCV Truck Trailer max 56 tons,efficiency,2.8363,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022.0
-FCV Truck Trailer max 56 tons,investment,278063.892,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022.0
-FCV Truck Trailer max 56 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022.0
-FT fuel transport ship,FOM,5.0,%/year,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020.0
-FT fuel transport ship,capacity,75000.0,t_FTfuel,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020.0
-FT fuel transport ship,investment,35000000.0,EUR,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020.0
-FT fuel transport ship,lifetime,15.0,years,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020.0
-Fischer-Tropsch,FOM,3.0,%/year,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), section 6.3.2.1.",,2017.0
-Fischer-Tropsch,VOM,4.4663,EUR/MWh_FT,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",102 Hydrogen to Jet:  Variable O&M,2020.0
+CO2 liquefaction,investment,16.7226,EUR/t_CO2/h,Mitsubish Heavy Industries Ltd. and IEA (2004): https://ieaghg.org/docs/General_Docs/Reports/PH4-30%20Ship%20Transport.pdf .,"Plant capacity of 20 kt CO2 / d and an uptime of 85%. For a high purity, humid, low pressure input stream, includes drying and compression necessary for liquefaction.",2004
+CO2 liquefaction,lifetime,25,years,"Guesstimate, based on CH4 liquefaction.",,2004
+CO2 pipeline,FOM,0.9,%/year,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",,2015
+CO2 pipeline,investment,2116.4433,EUR/(tCO2/h)/km,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",Assuming the 120-500 t CO2/h range that is based on cost of a 12 inch onshore pipeline.,2015
+CO2 pipeline,lifetime,50,years,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",,2015
+CO2 storage tank,FOM,1,%/year,"Lauri et al. 2014: doi: 10.1016/j.egypro.2014.11.297, pg. 2746 .","Assuming a 3000m^3 pressurised steel cylinder tanks and a CO2 density of 1100 kg/m^3 (close to triple point at -56.6°C and 5.2 bar with max density of 1200kg/m^3 ). Lauri et al. report costs 3x higher per m^3 for steel tanks, which are consistent with other sources. The numbers reported are in rather difficult to pinpoint as systems can greatly vary.",2013
+CO2 storage tank,investment,2584.3462,EUR/t_CO2,"Lauri et al. 2014: doi: 10.1016/j.egypro.2014.11.297, Table 3.","Assuming a 3000m^3 pressurised steel cylinder tanks and a CO2 density of 1100 kg/m^3 (close to triple point at -56.6°C and 5.2 bar with max density of 1200kg/m^3 ). Lauri et al. report costs 3x higher per m^3 for steel tanks, which are consistent with other sources. The numbers reported are in rather difficult to pinpoint as systems can greatly vary.",2013
+CO2 storage tank,lifetime,25,years,"Lauri et al. 2014: doi: 10.1016/j.egypro.2014.11.297, pg. 2746 .","Assuming a 3000m^3 pressurised steel cylinder tanks and a CO2 density of 1100 kg/m^3 (close to triple point at -56.6°C and 5.2 bar with max density of 1200kg/m^3 ). Lauri et al. report costs 3x higher per m^3 for steel tanks, which are consistent with other sources. The numbers reported are in rather difficult to pinpoint as systems can greatly vary.",2013
+CO2 submarine pipeline,FOM,0.5,%/year,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",,2015
+CO2 submarine pipeline,investment,4232.8865,EUR/(tCO2/h)/km,"Danish Energy Agency, Technology Data for Energy Transport (March 2021), Excel datasheet: 121 co2 pipeline.",Assuming the 120-500 t CO2/h range that is based on cost of a 12 inch offshore pipeline.,2015
+Charging infrastructure fast (purely) battery electric vehicles passenger cars,FOM,1.6,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fast (purely) battery electric vehicles passenger cars,2020
+Charging infrastructure fast (purely) battery electric vehicles passenger cars,investment,448894,EUR/Ladesï¿½ule,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fast (purely) battery electric vehicles passenger cars,2020
+Charging infrastructure fast (purely) battery electric vehicles passenger cars,lifetime,30,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fast (purely) battery electric vehicles passenger cars,2020
+Charging infrastructure fuel cell vehicles passenger cars,FOM,2.2,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles passenger cars,2020
+Charging infrastructure fuel cell vehicles passenger cars,investment,1787894,EUR/Ladesï¿½ule,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles passenger cars,2020
+Charging infrastructure fuel cell vehicles passenger cars,lifetime,30,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles passenger cars,2020
+Charging infrastructure fuel cell vehicles trucks,FOM,2.2,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles trucks,2020
+Charging infrastructure fuel cell vehicles trucks,investment,1787894,EUR/Ladesï¿½ule,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles trucks,2020
+Charging infrastructure fuel cell vehicles trucks,lifetime,30,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure fuel cell vehicles trucks,2020
+Charging infrastructure slow (purely) battery electric vehicles passenger cars,FOM,1.8,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure slow (purely) battery electric vehicles passenger cars,2020
+Charging infrastructure slow (purely) battery electric vehicles passenger cars,investment,1005,EUR/Ladesï¿½ule,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure slow (purely) battery electric vehicles passenger cars,2020
+Charging infrastructure slow (purely) battery electric vehicles passenger cars,lifetime,30,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Charging infrastructure slow (purely) battery electric vehicles passenger cars,2020
+Compressed-Air-Adiabatic-bicharger,FOM,0.9265,%/year,"Viswanathan_2022, p.64 (p.86) Figure 4.14","{'carrier': ['elec', 'pair', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Compressed-Air-Adiabatic-bicharger,efficiency,0.7211,per unit,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'pair', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level 0.52^0.5']}",2020
+Compressed-Air-Adiabatic-bicharger,investment,946180.9426,EUR/MW,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'pair', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Turbine Compressor BOP EPC Management']}",2020
+Compressed-Air-Adiabatic-bicharger,lifetime,60,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'pair', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Compressed-Air-Adiabatic-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB 4.5.2.1 Fixed O&M p.62 (p.84)","{'carrier': ['pair'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020
+Compressed-Air-Adiabatic-store,investment,5448.7894,EUR/MWh,"Viswanathan_2022, p.64 (p.86)","{'carrier': ['pair'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Cavern Storage']}",2020
+Compressed-Air-Adiabatic-store,lifetime,60,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['pair'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Concrete-charger,FOM,1.075,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'concrete'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020
+Concrete-charger,efficiency,0.99,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'concrete'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020
+Concrete-charger,investment,144192.2682,EUR/MW,"Georgiou_2018, Guesstimate that charge is 20% of capital costs of power components for sensible thermal storage","{'carrier': ['elec', 'concrete'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020
+Concrete-charger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'concrete'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Concrete-discharger,FOM,0.2688,%/year,"Viswanathan_2022, NULL","{'carrier': ['concrete', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020
+Concrete-discharger,efficiency,0.4343,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['concrete', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020
+Concrete-discharger,investment,576769.073,EUR/MW,"Georgiou_2018, Guesstimate that charge is 80% of capital costs of power components for sensible thermal storage","{'carrier': ['concrete', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020
+Concrete-discharger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['concrete', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Concrete-store,FOM,0.3308,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['concrete'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020
+Concrete-store,investment,24044.2324,EUR/MWh,"Viswanathan_2022, p.98 (p.120)","{'carrier': ['concrete'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['SB and BOS 0.85 of 2021 value']}",2020
+Concrete-store,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['concrete'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020
+"Container feeder, ammonia",efficiency,0.7754,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, ammonia",2023
+"Container feeder, ammonia",investment,38462833.2276,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, ammonia",2023
+"Container feeder, ammonia",lifetime,30,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, ammonia",2023
+"Container feeder, diesel",efficiency,0.7718,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, diesel",2023
+"Container feeder, diesel",investment,34966212.0251,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, diesel",2023
+"Container feeder, diesel",lifetime,30,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, diesel",2023
+"Container feeder, methanol",efficiency,0.7711,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, methanol",2023
+"Container feeder, methanol",investment,36802136.8043,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, methanol",2023
+"Container feeder, methanol",lifetime,30,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container feeder, methanol",2023
+"Container, ammonia",efficiency,1.7094,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, ammonia",2023
+"Container, ammonia",investment,131618242.0136,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, ammonia",2023
+"Container, ammonia",lifetime,31,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, ammonia",2023
+"Container, diesel",efficiency,1.6399,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, diesel",2023
+"Container, diesel",investment,119652947.2851,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, diesel",2023
+"Container, diesel",lifetime,32,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, diesel",2023
+"Container, methanol",efficiency,1.7001,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, methanol",2023
+"Container, methanol",investment,125635594.6493,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, methanol",2023
+"Container, methanol",lifetime,32,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Container, methanol",2023
+Diesel Bus city,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022
+Diesel Bus city,Motor size,250,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022
+Diesel Bus city,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022
+Diesel Bus city,efficiency,2.0824,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022
+Diesel Bus city,investment,150756.2732,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022
+Diesel Bus city,lifetime,12,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B1,2022
+Diesel Coach,FOM,0.0003,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022
+Diesel Coach,Motor size,350,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022
+Diesel Coach,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022
+Diesel Coach,efficiency,2.2009,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022
+Diesel Coach,investment,231296.0768,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022
+Diesel Coach,lifetime,12,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel B2,2022
+Diesel Truck Semi-Trailer max 50 tons,FOM,0.0005,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022
+Diesel Truck Semi-Trailer max 50 tons,Motor size,380,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022
+Diesel Truck Semi-Trailer max 50 tons,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022
+Diesel Truck Semi-Trailer max 50 tons,efficiency,3.2963,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022
+Diesel Truck Semi-Trailer max 50 tons,investment,142012.114,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022
+Diesel Truck Semi-Trailer max 50 tons,lifetime,10.5,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L3,2022
+Diesel Truck Solo max 26 tons,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022
+Diesel Truck Solo max 26 tons,Motor size,254.1379,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022
+Diesel Truck Solo max 26 tons,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022
+Diesel Truck Solo max 26 tons,efficiency,2.1867,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022
+Diesel Truck Solo max 26 tons,investment,155444.0931,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022
+Diesel Truck Solo max 26 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L1,2022
+Diesel Truck Trailer max 56 tons,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022
+Diesel Truck Trailer max 56 tons,Motor size,382.3529,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022
+Diesel Truck Trailer max 56 tons,VOM,0.1068,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022
+Diesel Truck Trailer max 56 tons,efficiency,3.3031,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022
+Diesel Truck Trailer max 56 tons,investment,177515.1425,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022
+Diesel Truck Trailer max 56 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",Diesel L2,2022
+FCV Bus city,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022
+FCV Bus city,Motor size,390.6897,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022
+FCV Bus city,VOM,0.0979,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022
+FCV Bus city,efficiency,1.5899,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022
+FCV Bus city,investment,323056.5642,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022
+FCV Bus city,lifetime,12,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B1,2022
+FCV Coach,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022
+FCV Coach,Motor size,390.6897,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022
+FCV Coach,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022
+FCV Coach,efficiency,1.5761,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022
+FCV Coach,investment,356840.1722,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022
+FCV Coach,lifetime,12,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV B2,2022
+FCV Truck Semi-Trailer max 50 tons,FOM,0.0004,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022
+FCV Truck Semi-Trailer max 50 tons,Motor size,513.7931,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022
+FCV Truck Semi-Trailer max 50 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022
+FCV Truck Semi-Trailer max 50 tons,efficiency,2.548,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022
+FCV Truck Semi-Trailer max 50 tons,investment,139809.9795,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022
+FCV Truck Semi-Trailer max 50 tons,lifetime,10.5,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L3,2022
+FCV Truck Solo max 26 tons,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022
+FCV Truck Solo max 26 tons,Motor size,381.0345,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022
+FCV Truck Solo max 26 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022
+FCV Truck Solo max 26 tons,efficiency,1.7064,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022
+FCV Truck Solo max 26 tons,investment,255992.8427,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022
+FCV Truck Solo max 26 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L1,2022
+FCV Truck Trailer max 56 tons,FOM,0.0002,%/year,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022
+FCV Truck Trailer max 56 tons,Motor size,381.0345,kW,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022
+FCV Truck Trailer max 56 tons,VOM,0.0952,EUR/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022
+FCV Truck Trailer max 56 tons,efficiency,2.8363,kWh/km,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022
+FCV Truck Trailer max 56 tons,investment,278063.892,EUR/vehicle,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022
+FCV Truck Trailer max 56 tons,lifetime,13.8,years,"Danish Energy Agency, inputs/data_sheets_for_commercial_freight_and_passenger_transport_0.xlsx",FCV L2,2022
+FT fuel transport ship,FOM,5,%/year,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020
+FT fuel transport ship,capacity,75000,t_FTfuel,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020
+FT fuel transport ship,investment,35000000,EUR,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020
+FT fuel transport ship,lifetime,15,years,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020
+Fischer-Tropsch,FOM,3,%/year,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), section 6.3.2.1.",,2017
+Fischer-Tropsch,VOM,4.4663,EUR/MWh_FT,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",102 Hydrogen to Jet:  Variable O&M,2020
 Fischer-Tropsch,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 Fischer-Tropsch,carbondioxide-input,0.326,t_CO2/MWh_FT,"DEA (2022): Technology Data for Renewable Fuels (https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-renewable-fuels), Hydrogen to Jet Fuel, Table 10 / pg. 267.","Input per 1t FT liquid fuels output, carbon efficiency increases with years (4.3, 3.9, 3.6, 3.3 t_CO2/t_FT from 2020-2050 with LHV 11.95 MWh_th/t_FT).",
-Fischer-Tropsch,efficiency,0.799,per unit,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), section 6.3.2.2.",,2017.0
+Fischer-Tropsch,efficiency,0.799,per unit,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), section 6.3.2.2.",,2017
 Fischer-Tropsch,electricity-input,0.007,MWh_el/MWh_FT,"DEA (2022): Technology Data for Renewable Fuels (https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-renewable-fuels), Hydrogen to Jet Fuel, Table 10 / pg. 267.","0.005 MWh_el input per FT output, output increasing from 2020 to 2050 (0.65, 0.7, 0.73, 0.75 MWh liquid FT output).",
 Fischer-Tropsch,hydrogen-input,1.421,MWh_H2/MWh_FT,"DEA (2022): Technology Data for Renewable Fuels (https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-renewable-fuels), Hydrogen to Jet Fuel, Table 10 / pg. 267.","0.995 MWh_H2 per output, output increasing from 2020 to 2050 (0.65, 0.7, 0.73, 0.75 MWh liquid FT output).",
-Fischer-Tropsch,investment,703726.4462,EUR/MW_FT,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), table 8: “Reference scenario”.","Well developed technology, no significant learning expected.",2017.0
-Fischer-Tropsch,lifetime,20.0,years,"Danish Energy Agency, Technology Data for Renewable Fuels (04/2022), Data sheet “Methanol to Power”.",,2017.0
-Gasnetz,FOM,2.5,%,"WEGE ZU EINEM KLIMANEUTRALEN ENERGIESYSEM, Anhang zur Studie, Fraunhofer-Institut für Solare Energiesysteme ISE, Freiburg",Gasnetz,2020.0
-Gasnetz,investment,28.0,EUR/kWGas,"WEGE ZU EINEM KLIMANEUTRALEN ENERGIESYSEM, Anhang zur Studie, Fraunhofer-Institut für Solare Energiesysteme ISE, Freiburg",Gasnetz,2020.0
-Gasnetz,lifetime,30.0,years,"WEGE ZU EINEM KLIMANEUTRALEN ENERGIESYSEM, Anhang zur Studie, Fraunhofer-Institut für Solare Energiesysteme ISE, Freiburg",Gasnetz,2020.0
-General liquid hydrocarbon storage (crude),FOM,6.25,%/year,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , figure 7 and pg. 12 .",Assuming ca. 10 EUR/m^3/a (center value between stand alone and addon facility).,2012.0
-General liquid hydrocarbon storage (crude),investment,137.8999,EUR/m^3,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , pg. 8F .",Assumed 20% lower than for product storage. Crude or middle distillate tanks are usually larger compared to product storage due to lower requirements on safety and different construction method. Reference size used here: 80 000 – 120 000 m^3 .,2012.0
-General liquid hydrocarbon storage (crude),lifetime,30.0,years,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , pg. 11.",,2012.0
-General liquid hydrocarbon storage (product),FOM,6.25,%/year,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , figure 7 and pg. 12 .",Assuming ca. 10 EUR/m^3/a (center value between stand alone and addon facility).,2012.0
-General liquid hydrocarbon storage (product),investment,172.3748,EUR/m^3,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , pg. 8F .",Assumed at the higher end for addon facilities/mid-range for stand-alone facilities. Product storage usually smaller due to higher requirements on safety and different construction method. Reference size used here: 40 000 – 60 000 m^3 .,2012.0
-General liquid hydrocarbon storage (product),lifetime,30.0,years,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , pg. 11.",,2012.0
-Gravity-Brick-bicharger,FOM,1.5,%/year,"Viswanathan_2022, p.76 (p.98) Sentence 1 in 4.7.2 Operating Costs","{'carrier': ['elec', 'gravity', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['1.5 percent of capital cost']}",2020.0
-Gravity-Brick-bicharger,efficiency,0.9274,per unit,"Viswanathan_2022, p.77 (p.99) Table 4.36","{'carrier': ['elec', 'gravity', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level 0.86^0.5']}",2020.0
-Gravity-Brick-bicharger,investment,415570.5177,EUR/MW,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 0% cost reduction for 2030 compared to 2021","{'carrier': ['elec', 'gravity', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Power Equipment']}",2020.0
-Gravity-Brick-bicharger,lifetime,41.7,years,"Viswanathan_2022, p.77 (p.99) Table 4.36","{'carrier': ['elec', 'gravity', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Gravity-Brick-store,investment,157381.7274,EUR/MWh,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 15% cost reduction for 2030 compared to 2021","{'carrier': ['gravity'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Gravitational Capital (SB+BOS)']}",2020.0
-Gravity-Brick-store,lifetime,41.7,years,"Viswanathan_2022, p.77 (p.99) Table 4.36","{'carrier': ['gravity'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Gravity-Water-Aboveground-bicharger,FOM,1.5,%/year,"Viswanathan_2022, p.76 (p.98) Sentence 1 in 4.7.2 Operating Costs","{'carrier': ['elec', 'gravitywa', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['1.5 percent of capital cost']}",2020.0
-Gravity-Water-Aboveground-bicharger,efficiency,0.9014,per unit,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['elec', 'gravitywa', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level ((0.785+0.84)/2)^0.5']}",2020.0
-Gravity-Water-Aboveground-bicharger,investment,365630.713,EUR/MW,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 0% cost reduction for 2030 compared to 2021","{'carrier': ['elec', 'gravitywa', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Power Equipment']}",2020.0
-Gravity-Water-Aboveground-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['elec', 'gravitywa', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Gravity-Water-Aboveground-store,investment,121755.0274,EUR/MWh,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 15% cost reduction for 2030 compared to 2021","{'carrier': ['gravitywa'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Gravitational Capital (SB+BOS)']}",2020.0
-Gravity-Water-Aboveground-store,lifetime,60.0,years,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['gravitywa'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Gravity-Water-Underground-bicharger,FOM,1.5,%/year,"Viswanathan_2022, p.76 (p.98) Sentence 1 in 4.7.2 Operating Costs","{'carrier': ['elec', 'gravitywu', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['1.5 percent of capital cost']}",2020.0
-Gravity-Water-Underground-bicharger,efficiency,0.9014,per unit,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['elec', 'gravitywu', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level ((0.785+0.84)/2)^0.5']}",2020.0
-Gravity-Water-Underground-bicharger,investment,905158.9602,EUR/MW,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 0% cost reduction for 2030 compared to 2021","{'carrier': ['elec', 'gravitywu', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Power Equipment']}",2020.0
-Gravity-Water-Underground-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['elec', 'gravitywu', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Gravity-Water-Underground-store,investment,95982.5211,EUR/MWh,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 15% cost reduction for 2030 compared to 2021","{'carrier': ['gravitywu'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Gravitational Capital (SB+BOS)']}",2020.0
-Gravity-Water-Underground-store,lifetime,60.0,years,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['gravitywu'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-H2 (g) fill compressor station,FOM,1.7,%/year,"Guidehouse 2020: European Hydrogen Backbone report, https://guidehouse.com/-/media/www/site/downloads/energy/2020/gh_european-hydrogen-backbone_report.pdf (table 3, table 5)","Pessimistic (highest) value chosen for 48'' pipeline w/ 13GW_H2 LHV @ 100bar pressure. Currency year: Not clearly specified, assuming year of publication. Forecast year: Not clearly specified, guessing based on text remarks.",2020.0
-H2 (g) fill compressor station,investment,4738.7164,EUR/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), pg. 164, Figure 14 (Fill compressor).","Assumption for staging 35→140bar, 6000 MW_HHV single line pipeline. Considering HHV/LHV ration for H2.",2015.0
-H2 (g) fill compressor station,lifetime,20.0,years,"Danish Energy Agency, Technology Data for Energy Transport (2021), pg. 168, Figure 24 (Fill compressor).",,2015.0
-H2 (g) pipeline,FOM,3.1667,%/year,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, > 6000 MW_HHV single line pipeline, incl. booster station investments. Considering LHV by scaling with LHV/HHV=0.8462623413.",2015.0
-H2 (g) pipeline,electricity-input,0.019,MW_e/1000km/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, 5-20 GW pipeline. Electric compression.",2015.0
-H2 (g) pipeline,investment,303.6845,EUR/MW/km,European Hydrogen Backbone Report (June 2021): https://gasforclimate2050.eu/wp-content/uploads/2021/06/EHB_Analysing-the-future-demand-supply-and-transport-of-hydrogen_June-2021.pdf Table 35. Implementation roadmap - Cross border projects and costs updates: https://ehb.eu/files/downloads/EHB-2023-20-Nov-FINAL-design.pdf Table 1,"Assumption for a 48 inch single line pipeline, incl. compressor investments, 16.9 GW (LHV) peak capacity (source 2), 4.4 MEUR/km base cost with additional investment for compressors of capacity 434 MWe/1000 km (source 1), at 4 MEUR/MWe for compressor (source 2)",2023.0
-H2 (g) pipeline,lifetime,50.0,years,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, > 6000 MW_HHV single line pipeline, incl. booster station investments. Considering LHV by scaling with LHV/HHV=0.8462623413.",2015.0
-H2 (g) pipeline repurposed,FOM,3.1667,%/year,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.",Same as for new H2 (g) pipeline.,2015.0
-H2 (g) pipeline repurposed,electricity-input,0.019,MW_e/1000km/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, 5-20 GW pipeline. Electric compression.",2015.0
-H2 (g) pipeline repurposed,investment,129.4682,EUR/MW/km,European Hydrogen Backbone Report (June 2021): https://gasforclimate2050.eu/wp-content/uploads/2021/06/EHB_Analysing-the-future-demand-supply-and-transport-of-hydrogen_June-2021.pdf Table 35. Implementation roadmap - Cross border projects and costs updates: https://ehb.eu/files/downloads/EHB-2023-20-Nov-FINAL-design.pdf Table 1,"Assumption for a 48 inch single line repurposed pipeline, incl. compressor investments, 16.9 GW (LHV) peak capacity (source 2), 0.8 MEUR/km base cost with additional investment for compressors of capacity 434 MWe/1000 km (source 1), at 4 MEUR/MWe for compressor (source 2)",2023.0
-H2 (g) pipeline repurposed,lifetime,50.0,years,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.",Same as for new H2 (g) pipeline.,2015.0
-H2 (g) submarine pipeline,FOM,3.0,%/year,Assume same as for CH4 (g) submarine pipeline.,-,2015.0
-H2 (g) submarine pipeline,electricity-input,0.019,MW_e/1000km/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, 5-20 GW pipeline. Electric compression.",2015.0
-H2 (g) submarine pipeline,investment,456.1165,EUR/MW/km,European Hydrogen Backbone Report (June 2021): https://gasforclimate2050.eu/wp-content/uploads/2021/06/EHB_Analysing-the-future-demand-supply-and-transport-of-hydrogen_June-2021.pdf Table 35. Implementation roadmap - Cross border projects and costs updates: https://ehb.eu/files/downloads/EHB-2023-20-Nov-FINAL-design.pdf Table 1,"Assumption for a 48 inch single line offshore pipeline, incl. compressor investments, 16.9 GW (LHV) peak capacity (source 2), 7.48 MEUR/km base cost with additional investment for compressors of capacity 434 MWe/1000 km (source 1), at 4 MEUR/MWe for compressor (source 2)",2023.0
-H2 (g) submarine pipeline,lifetime,30.0,years,Assume same as for CH4 (g) submarine pipeline.,-,2015.0
-H2 (g) submarine pipeline repurposed,FOM,3.0,%/year,Assume same as for CH4 (g) submarine pipeline.,-,2015.0
-H2 (g) submarine pipeline repurposed,electricity-input,0.019,MW_e/1000km/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, 5-20 GW pipeline. Electric compression.",2015.0
-H2 (g) submarine pipeline repurposed,investment,160.1562,EUR/MW/km,European Hydrogen Backbone Report (June 2021): https://gasforclimate2050.eu/wp-content/uploads/2021/06/EHB_Analysing-the-future-demand-supply-and-transport-of-hydrogen_June-2021.pdf Table 35. Implementation roadmap - Cross border projects and costs updates: https://ehb.eu/files/downloads/EHB-2023-20-Nov-FINAL-design.pdf Table 1,"Assumption for a 48 inch single line repurposed offshore pipeline, incl. compressor investments, 16.9 GW (LHV) peak capacity (source 2), 1.5 MEUR/km base cost with additional investment for compressors of capacity 434 MWe/1000 km (source 1), at 4 MEUR/MWe for compressor (source 2)",2023.0
-H2 (g) submarine pipeline repurposed,lifetime,30.0,years,Assume same as for CH4 (g) submarine pipeline.,-,2015.0
-H2 (l) storage tank,FOM,2.0,%/year,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 6.",Assuming currency year and technology year here (25 EUR/kg).,2015.0
-H2 (l) storage tank,investment,793.7456,EUR/MWh_H2,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 6.","Assuming currency year and technology year here (25 EUR/kg). Future target cost. Today’s cost potentially higher according to d’Amore-Domenech et al (2021): 10.1016/j.apenergy.2021.116625 , supplementary material pg. 16.",2015.0
-H2 (l) storage tank,lifetime,20.0,years,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 6.",Assuming currency year and technology year here (25 EUR/kg).,2015.0
-H2 (l) transport ship,FOM,4.0,%/year,"Cihlar et al 2020: http://op.europa.eu/en/publication-detail/-/publication/7e4afa7d-d077-11ea-adf7-01aa75ed71a1/language-en , Table 3-B, based on IEA 2019.",,2019.0
-H2 (l) transport ship,capacity,11000.0,t_H2,"Cihlar et al 2020: http://op.europa.eu/en/publication-detail/-/publication/7e4afa7d-d077-11ea-adf7-01aa75ed71a1/language-en , Table 3-B, based on IEA 2019.",,2019.0
-H2 (l) transport ship,investment,393737000.0,EUR,"Cihlar et al 2020: http://op.europa.eu/en/publication-detail/-/publication/7e4afa7d-d077-11ea-adf7-01aa75ed71a1/language-en , Table 3-B, based on IEA 2019.",,2019.0
-H2 (l) transport ship,lifetime,20.0,years,"Cihlar et al 2020: http://op.europa.eu/en/publication-detail/-/publication/7e4afa7d-d077-11ea-adf7-01aa75ed71a1/language-en , Table 3-B, based on IEA 2019.",,2019.0
-H2 evaporation,FOM,2.5,%/year,"DNV GL (2020): Study on the Import of Liquid Renewable Energy: Technology Cost Assessment, https://www.gie.eu/wp-content/uploads/filr/2598/DNV-GL_Study-GLE-Technologies-and-costs-analysis-on-imports-of-liquid-renewable-energy.pdf .",,2020.0
+Fischer-Tropsch,investment,703726.4462,EUR/MW_FT,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), table 8: “Reference scenario”.","Well developed technology, no significant learning expected.",2017
+Fischer-Tropsch,lifetime,20,years,"Danish Energy Agency, Technology Data for Renewable Fuels (04/2022), Data sheet “Methanol to Power”.",,2017
+Gasnetz,FOM,2.5,%,"WEGE ZU EINEM KLIMANEUTRALEN ENERGIESYSEM, Anhang zur Studie, Fraunhofer-Institut für Solare Energiesysteme ISE, Freiburg",Gasnetz,2020
+Gasnetz,investment,28,EUR/kWGas,"WEGE ZU EINEM KLIMANEUTRALEN ENERGIESYSEM, Anhang zur Studie, Fraunhofer-Institut für Solare Energiesysteme ISE, Freiburg",Gasnetz,2020
+Gasnetz,lifetime,30,years,"WEGE ZU EINEM KLIMANEUTRALEN ENERGIESYSEM, Anhang zur Studie, Fraunhofer-Institut für Solare Energiesysteme ISE, Freiburg",Gasnetz,2020
+General liquid hydrocarbon storage (crude),FOM,6.25,%/year,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , figure 7 and pg. 12 .",Assuming ca. 10 EUR/m^3/a (center value between stand alone and addon facility).,2012
+General liquid hydrocarbon storage (crude),investment,137.8999,EUR/m^3,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , pg. 8F .",Assumed 20% lower than for product storage. Crude or middle distillate tanks are usually larger compared to product storage due to lower requirements on safety and different construction method. Reference size used here: 80 000 – 120 000 m^3 .,2012
+General liquid hydrocarbon storage (crude),lifetime,30,years,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , pg. 11.",,2012
+General liquid hydrocarbon storage (product),FOM,6.25,%/year,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , figure 7 and pg. 12 .",Assuming ca. 10 EUR/m^3/a (center value between stand alone and addon facility).,2012
+General liquid hydrocarbon storage (product),investment,172.3748,EUR/m^3,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , pg. 8F .",Assumed at the higher end for addon facilities/mid-range for stand-alone facilities. Product storage usually smaller due to higher requirements on safety and different construction method. Reference size used here: 40 000 – 60 000 m^3 .,2012
+General liquid hydrocarbon storage (product),lifetime,30,years,"Stelter and Nishida 2013: https://webstore.iea.org/insights-series-2013-focus-on-energy-security , pg. 11.",,2012
+Gravity-Brick-bicharger,FOM,1.5,%/year,"Viswanathan_2022, p.76 (p.98) Sentence 1 in 4.7.2 Operating Costs","{'carrier': ['elec', 'gravity', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['1.5 percent of capital cost']}",2020
+Gravity-Brick-bicharger,efficiency,0.9274,per unit,"Viswanathan_2022, p.77 (p.99) Table 4.36","{'carrier': ['elec', 'gravity', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level 0.86^0.5']}",2020
+Gravity-Brick-bicharger,investment,415570.5177,EUR/MW,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 0% cost reduction for 2030 compared to 2021","{'carrier': ['elec', 'gravity', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Power Equipment']}",2020
+Gravity-Brick-bicharger,lifetime,41.7,years,"Viswanathan_2022, p.77 (p.99) Table 4.36","{'carrier': ['elec', 'gravity', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Gravity-Brick-store,investment,157381.7274,EUR/MWh,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 15% cost reduction for 2030 compared to 2021","{'carrier': ['gravity'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Gravitational Capital (SB+BOS)']}",2020
+Gravity-Brick-store,lifetime,41.7,years,"Viswanathan_2022, p.77 (p.99) Table 4.36","{'carrier': ['gravity'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Gravity-Water-Aboveground-bicharger,FOM,1.5,%/year,"Viswanathan_2022, p.76 (p.98) Sentence 1 in 4.7.2 Operating Costs","{'carrier': ['elec', 'gravitywa', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['1.5 percent of capital cost']}",2020
+Gravity-Water-Aboveground-bicharger,efficiency,0.9014,per unit,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['elec', 'gravitywa', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level ((0.785+0.84)/2)^0.5']}",2020
+Gravity-Water-Aboveground-bicharger,investment,365630.713,EUR/MW,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 0% cost reduction for 2030 compared to 2021","{'carrier': ['elec', 'gravitywa', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Power Equipment']}",2020
+Gravity-Water-Aboveground-bicharger,lifetime,60,years,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['elec', 'gravitywa', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Gravity-Water-Aboveground-store,investment,121755.0274,EUR/MWh,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 15% cost reduction for 2030 compared to 2021","{'carrier': ['gravitywa'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Gravitational Capital (SB+BOS)']}",2020
+Gravity-Water-Aboveground-store,lifetime,60,years,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['gravitywa'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Gravity-Water-Underground-bicharger,FOM,1.5,%/year,"Viswanathan_2022, p.76 (p.98) Sentence 1 in 4.7.2 Operating Costs","{'carrier': ['elec', 'gravitywu', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['1.5 percent of capital cost']}",2020
+Gravity-Water-Underground-bicharger,efficiency,0.9014,per unit,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['elec', 'gravitywu', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level ((0.785+0.84)/2)^0.5']}",2020
+Gravity-Water-Underground-bicharger,investment,905158.9602,EUR/MW,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 0% cost reduction for 2030 compared to 2021","{'carrier': ['elec', 'gravitywu', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Power Equipment']}",2020
+Gravity-Water-Underground-bicharger,lifetime,60,years,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['elec', 'gravitywu', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Gravity-Water-Underground-store,investment,95982.5211,EUR/MWh,"Viswanathan_2022, p.71 (p.94) text at the bottom speaks about 15% cost reduction for 2030 compared to 2021","{'carrier': ['gravitywu'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Gravitational Capital (SB+BOS)']}",2020
+Gravity-Water-Underground-store,lifetime,60,years,"Viswanathan_2022, p.77 (p.99) Table 4.37","{'carrier': ['gravitywu'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+H2 (g) fill compressor station,FOM,1.7,%/year,"Guidehouse 2020: European Hydrogen Backbone report, https://guidehouse.com/-/media/www/site/downloads/energy/2020/gh_european-hydrogen-backbone_report.pdf (table 3, table 5)","Pessimistic (highest) value chosen for 48'' pipeline w/ 13GW_H2 LHV @ 100bar pressure. Currency year: Not clearly specified, assuming year of publication. Forecast year: Not clearly specified, guessing based on text remarks.",2020
+H2 (g) fill compressor station,investment,4738.7164,EUR/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), pg. 164, Figure 14 (Fill compressor).","Assumption for staging 35→140bar, 6000 MW_HHV single line pipeline. Considering HHV/LHV ration for H2.",2015
+H2 (g) fill compressor station,lifetime,20,years,"Danish Energy Agency, Technology Data for Energy Transport (2021), pg. 168, Figure 24 (Fill compressor).",,2015
+H2 (g) pipeline,FOM,3.1667,%/year,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, > 6000 MW_HHV single line pipeline, incl. booster station investments. Considering LHV by scaling with LHV/HHV=0.8462623413.",2015
+H2 (g) pipeline,electricity-input,0.019,MW_e/1000km/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, 5-20 GW pipeline. Electric compression.",2015
+H2 (g) pipeline,investment,303.6845,EUR/MW/km,European Hydrogen Backbone Report (June 2021): https://gasforclimate2050.eu/wp-content/uploads/2021/06/EHB_Analysing-the-future-demand-supply-and-transport-of-hydrogen_June-2021.pdf Table 35. Implementation roadmap - Cross border projects and costs updates: https://ehb.eu/files/downloads/EHB-2023-20-Nov-FINAL-design.pdf Table 1,"Assumption for a 48 inch single line pipeline, incl. compressor investments, 16.9 GW (LHV) peak capacity (source 2), 4.4 MEUR/km base cost with additional investment for compressors of capacity 434 MWe/1000 km (source 1), at 4 MEUR/MWe for compressor (source 2)",2023
+H2 (g) pipeline,lifetime,50,years,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, > 6000 MW_HHV single line pipeline, incl. booster station investments. Considering LHV by scaling with LHV/HHV=0.8462623413.",2015
+H2 (g) pipeline repurposed,FOM,3.1667,%/year,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.",Same as for new H2 (g) pipeline.,2015
+H2 (g) pipeline repurposed,electricity-input,0.019,MW_e/1000km/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, 5-20 GW pipeline. Electric compression.",2015
+H2 (g) pipeline repurposed,investment,129.4682,EUR/MW/km,European Hydrogen Backbone Report (June 2021): https://gasforclimate2050.eu/wp-content/uploads/2021/06/EHB_Analysing-the-future-demand-supply-and-transport-of-hydrogen_June-2021.pdf Table 35. Implementation roadmap - Cross border projects and costs updates: https://ehb.eu/files/downloads/EHB-2023-20-Nov-FINAL-design.pdf Table 1,"Assumption for a 48 inch single line repurposed pipeline, incl. compressor investments, 16.9 GW (LHV) peak capacity (source 2), 0.8 MEUR/km base cost with additional investment for compressors of capacity 434 MWe/1000 km (source 1), at 4 MEUR/MWe for compressor (source 2)",2023
+H2 (g) pipeline repurposed,lifetime,50,years,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.",Same as for new H2 (g) pipeline.,2015
+H2 (g) submarine pipeline,FOM,3,%/year,Assume same as for CH4 (g) submarine pipeline.,-,2015
+H2 (g) submarine pipeline,electricity-input,0.019,MW_e/1000km/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, 5-20 GW pipeline. Electric compression.",2015
+H2 (g) submarine pipeline,investment,456.1165,EUR/MW/km,European Hydrogen Backbone Report (June 2021): https://gasforclimate2050.eu/wp-content/uploads/2021/06/EHB_Analysing-the-future-demand-supply-and-transport-of-hydrogen_June-2021.pdf Table 35. Implementation roadmap - Cross border projects and costs updates: https://ehb.eu/files/downloads/EHB-2023-20-Nov-FINAL-design.pdf Table 1,"Assumption for a 48 inch single line offshore pipeline, incl. compressor investments, 16.9 GW (LHV) peak capacity (source 2), 7.48 MEUR/km base cost with additional investment for compressors of capacity 434 MWe/1000 km (source 1), at 4 MEUR/MWe for compressor (source 2)",2023
+H2 (g) submarine pipeline,lifetime,30,years,Assume same as for CH4 (g) submarine pipeline.,-,2015
+H2 (g) submarine pipeline repurposed,FOM,3,%/year,Assume same as for CH4 (g) submarine pipeline.,-,2015
+H2 (g) submarine pipeline repurposed,electricity-input,0.019,MW_e/1000km/MW_H2,"Danish Energy Agency, Technology Data for Energy Transport (2021), Excel datasheet: H2 140.","Assumption for a 140 bar, 5-20 GW pipeline. Electric compression.",2015
+H2 (g) submarine pipeline repurposed,investment,160.1562,EUR/MW/km,European Hydrogen Backbone Report (June 2021): https://gasforclimate2050.eu/wp-content/uploads/2021/06/EHB_Analysing-the-future-demand-supply-and-transport-of-hydrogen_June-2021.pdf Table 35. Implementation roadmap - Cross border projects and costs updates: https://ehb.eu/files/downloads/EHB-2023-20-Nov-FINAL-design.pdf Table 1,"Assumption for a 48 inch single line repurposed offshore pipeline, incl. compressor investments, 16.9 GW (LHV) peak capacity (source 2), 1.5 MEUR/km base cost with additional investment for compressors of capacity 434 MWe/1000 km (source 1), at 4 MEUR/MWe for compressor (source 2)",2023
+H2 (g) submarine pipeline repurposed,lifetime,30,years,Assume same as for CH4 (g) submarine pipeline.,-,2015
+H2 (l) storage tank,FOM,2,%/year,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 6.",Assuming currency year and technology year here (25 EUR/kg).,2015
+H2 (l) storage tank,investment,793.7456,EUR/MWh_H2,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 6.","Assuming currency year and technology year here (25 EUR/kg). Future target cost. Today’s cost potentially higher according to d’Amore-Domenech et al (2021): 10.1016/j.apenergy.2021.116625 , supplementary material pg. 16.",2015
+H2 (l) storage tank,lifetime,20,years,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 6.",Assuming currency year and technology year here (25 EUR/kg).,2015
+H2 (l) transport ship,FOM,4,%/year,"Cihlar et al 2020: http://op.europa.eu/en/publication-detail/-/publication/7e4afa7d-d077-11ea-adf7-01aa75ed71a1/language-en , Table 3-B, based on IEA 2019.",,2019
+H2 (l) transport ship,capacity,11000,t_H2,"Cihlar et al 2020: http://op.europa.eu/en/publication-detail/-/publication/7e4afa7d-d077-11ea-adf7-01aa75ed71a1/language-en , Table 3-B, based on IEA 2019.",,2019
+H2 (l) transport ship,investment,393737000,EUR,"Cihlar et al 2020: http://op.europa.eu/en/publication-detail/-/publication/7e4afa7d-d077-11ea-adf7-01aa75ed71a1/language-en , Table 3-B, based on IEA 2019.",,2019
+H2 (l) transport ship,lifetime,20,years,"Cihlar et al 2020: http://op.europa.eu/en/publication-detail/-/publication/7e4afa7d-d077-11ea-adf7-01aa75ed71a1/language-en , Table 3-B, based on IEA 2019.",,2019
+H2 evaporation,FOM,2.5,%/year,"DNV GL (2020): Study on the Import of Liquid Renewable Energy: Technology Cost Assessment, https://www.gie.eu/wp-content/uploads/filr/2598/DNV-GL_Study-GLE-Technologies-and-costs-analysis-on-imports-of-liquid-renewable-energy.pdf .",,2020
 H2 evaporation,investment,146.8405,EUR/kW_H2,"IRENA (2022): Global Hydrogen Trade to Meet the 1.5° Climate Goal: Technology Review of Hydrogen Carriers, https://www.irena.org/publications/2022/Apr/Global-hydrogen-trade-Part-II , pg. 62f.","Pessimistic assumption for large scale facility / near-term estimate for medium sized facility, in between low / mid estimate with e.g. DNV numbers (Fig. 3.15).; and
-Optimistic assumption for large scale facility 2500 t/d, cf Fig. 3.15 .",2022.0
-H2 evaporation,lifetime,20.0,years,Guesstimate.,Based on lifetime of liquefaction plant.,2015.0
-H2 liquefaction,FOM,2.5,%/year,"DNV GL (2020): Study on the Import of Liquid Renewable Energy: Technology Cost Assessment, https://www.gie.eu/wp-content/uploads/filr/2598/DNV-GL_Study-GLE-Technologies-and-costs-analysis-on-imports-of-liquid-renewable-energy.pdf .",,2020.0
+Optimistic assumption for large scale facility 2500 t/d, cf Fig. 3.15 .",2022
+H2 evaporation,lifetime,20,years,Guesstimate.,Based on lifetime of liquefaction plant.,2015
+H2 liquefaction,FOM,2.5,%/year,"DNV GL (2020): Study on the Import of Liquid Renewable Energy: Technology Cost Assessment, https://www.gie.eu/wp-content/uploads/filr/2598/DNV-GL_Study-GLE-Technologies-and-costs-analysis-on-imports-of-liquid-renewable-energy.pdf .",,2020
 H2 liquefaction,electricity-input,0.203,MWh_el/MWh_H2,"Heuser et al. (2019): Techno-economic analysis of a potential energy trading link between Patagonia and Japan based on CO2 free hydrogen (https://doi.org/10.1016/j.ijhydene.2018.12.156), table 1.","6.78 kWh/kg_H2, considering H2 with LHV of 33.3333 MWh/t",
 H2 liquefaction,hydrogen-input,1.017,MWh_H2/MWh_H2,"Heuser et al. (2019): Techno-economic analysis of a potential energy trading link between Patagonia and Japan based on CO2 free hydrogen (https://doi.org/10.1016/j.ijhydene.2018.12.156), table 1.",corresponding to 1.65% losses during liquefaction,
 H2 liquefaction,investment,889.9426,EUR/kW_H2,"IRENA (2022): Global Hydrogen Trade to Meet the 1.5° Climate Goal: Technology Review of Hydrogen Carriers, https://www.irena.org/publications/2022/Apr/Global-hydrogen-trade-Part-II , pg. 62f.","Assumption for a 200t/d facility (Pessimistic long-term or optimistic short-term value).; and
-Assumption for a large >300t/d, e.g. 2500 t/d facility (Optimistic long-term value without change in base technology mentioned in report).",2022.0
-H2 liquefaction,lifetime,20.0,years,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2022.0
-H2 pipeline,FOM,3.0,%/year,TODO, from old pypsa cost assumptions,2015.0
-H2 pipeline,investment,282.5452,EUR/MW/km,Welder et al https://doi.org/10.1016/j.energy.2018.05.059, from old pypsa cost assumptions,2015.0
-H2 pipeline,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
-HVAC overhead,FOM,2.0,%/year,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVAC overhead,investment,442.1414,EUR/MW/km,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVAC overhead,lifetime,40.0,years,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVDC inverter pair,FOM,2.0,%/year,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVDC inverter pair,investment,165803.0398,EUR/MW,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVDC inverter pair,lifetime,40.0,years,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVDC overhead,FOM,2.0,%/year,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVDC overhead,investment,442.1414,EUR/MW/km,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVDC overhead,lifetime,40.0,years,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011.0
-HVDC submarine,FOM,0.35,%/year,Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095 .,"Based on estimated costs for a NA-EU connector (bidirectional,4 GW, 3000km length and ca. 3000m depth). Costs in return based on existing/currently under construction undersea cables.",2018.0
-HVDC submarine,investment,1008.2934,EUR/MW/km,Härtel et al. (2017): https://doi.org/10.1016/j.epsr.2017.06.008 .,Table 1,2017.0
-HVDC submarine,lifetime,40.0,years,Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095 .,"Based on estimated costs for a NA-EU connector (bidirectional,4 GW, 3000km length and ca. 3000m depth). Costs in return based on existing/currently under construction undersea cables.",2018.0
-HVDC underground,FOM,0.35,%/year,Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095 .,"Based on estimated costs for a NA-EU connector (bidirectional,4 GW, 3000km length and ca. 3000m depth). Costs in return based on existing/currently under construction undersea cables. (same as for HVDC submarine)",2018.0
-HVDC underground,investment,1008.2934,EUR/MW/km,Härtel et al. (2017): https://doi.org/10.1016/j.epsr.2017.06.008 .,Table 1 (same as for HVDC submarine),2017.0
-HVDC underground,lifetime,40.0,years,Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095 .,"Based on estimated costs for a NA-EU connector (bidirectional,4 GW, 3000km length and ca. 3000m depth). Costs in return based on existing/currently under construction undersea cables. (same as for HVDC submarine)",2018.0
-Haber-Bosch,FOM,3.0,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Fixed O&M,2015.0
-Haber-Bosch,VOM,0.0225,EUR/MWh_NH3,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Variable O&M,2015.0
+Assumption for a large >300t/d, e.g. 2500 t/d facility (Optimistic long-term value without change in base technology mentioned in report).",2022
+H2 liquefaction,lifetime,20,years,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2022
+H2 pipeline,FOM,3,%/year,TODO, from old pypsa cost assumptions,2015
+H2 pipeline,investment,282.5452,EUR/MW/km,Welder et al https://doi.org/10.1016/j.energy.2018.05.059, from old pypsa cost assumptions,2015
+H2 pipeline,lifetime,40,years,TODO, from old pypsa cost assumptions,2015
+HVAC overhead,FOM,2,%/year,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVAC overhead,investment,442.1414,EUR/MW/km,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVAC overhead,lifetime,40,years,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVDC inverter pair,FOM,2,%/year,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVDC inverter pair,investment,165803.0398,EUR/MW,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVDC inverter pair,lifetime,40,years,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVDC overhead,FOM,2,%/year,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVDC overhead,investment,442.1414,EUR/MW/km,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVDC overhead,lifetime,40,years,"Hagspiel et al. (2014): doi:10.1016/j.energy.2014.01.025 , table A.2 .",,2011
+HVDC submarine,FOM,0.35,%/year,Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095 .,"Based on estimated costs for a NA-EU connector (bidirectional,4 GW, 3000km length and ca. 3000m depth). Costs in return based on existing/currently under construction undersea cables.",2018
+HVDC submarine,investment,1008.2934,EUR/MW/km,Härtel et al. (2017): https://doi.org/10.1016/j.epsr.2017.06.008 .,Table 1,2017
+HVDC submarine,lifetime,40,years,Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095 .,"Based on estimated costs for a NA-EU connector (bidirectional,4 GW, 3000km length and ca. 3000m depth). Costs in return based on existing/currently under construction undersea cables.",2018
+HVDC underground,FOM,0.35,%/year,Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095 .,"Based on estimated costs for a NA-EU connector (bidirectional,4 GW, 3000km length and ca. 3000m depth). Costs in return based on existing/currently under construction undersea cables. (same as for HVDC submarine)",2018
+HVDC underground,investment,1008.2934,EUR/MW/km,Härtel et al. (2017): https://doi.org/10.1016/j.epsr.2017.06.008 .,Table 1 (same as for HVDC submarine),2017
+HVDC underground,lifetime,40,years,Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095 .,"Based on estimated costs for a NA-EU connector (bidirectional,4 GW, 3000km length and ca. 3000m depth). Costs in return based on existing/currently under construction undersea cables. (same as for HVDC submarine)",2018
+Haber-Bosch,FOM,3,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Fixed O&M,2015
+Haber-Bosch,VOM,0.0225,EUR/MWh_NH3,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Variable O&M,2015
 Haber-Bosch,electricity-input,0.2473,MWh_el/MWh_NH3,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), table 11.",Assume 5 GJ/t_NH3 for compressors and NH3 LHV = 5.16666 MWh/t_NH3.,
 Haber-Bosch,hydrogen-input,1.1484,MWh_H2/MWh_NH3,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), pg. 57.","178 kg_H2 per t_NH3, LHV for both assumed.",
-Haber-Bosch,investment,1460.0135,EUR/kW_NH3,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Specific investment,2015.0
-Haber-Bosch,lifetime,30.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Technical lifetime,2015.0
+Haber-Bosch,investment,1460.0135,EUR/kW_NH3,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Specific investment,2015
+Haber-Bosch,lifetime,30,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Technical lifetime,2015
 Haber-Bosch,nitrogen-input,0.1597,t_N2/MWh_NH3,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), pg. 57.",".33 MWh electricity are required for ASU per t_NH3, considering 0.4 MWh are required per t_N2 and LHV of NH3 of 5.1666 Mwh.",
-HighT-Molten-Salt-charger,FOM,1.075,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'salthight'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020.0
-HighT-Molten-Salt-charger,efficiency,0.99,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'salthight'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020.0
-HighT-Molten-Salt-charger,investment,144192.2682,EUR/MW,"Georgiou_2018, Guesstimate that charge is 20% of capital costs of power components for sensible thermal storage","{'carrier': ['elec', 'salthight'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020.0
-HighT-Molten-Salt-charger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'salthight'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-HighT-Molten-Salt-discharger,FOM,0.2688,%/year,"Viswanathan_2022, NULL","{'carrier': ['salthight', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020.0
-HighT-Molten-Salt-discharger,efficiency,0.4444,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['salthight', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020.0
-HighT-Molten-Salt-discharger,investment,576769.073,EUR/MW,"Georgiou_2018, Guesstimate that charge is 80% of capital costs of power components for sensible thermal storage","{'carrier': ['salthight', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020.0
-HighT-Molten-Salt-discharger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['salthight', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-HighT-Molten-Salt-store,FOM,0.3308,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['salthight'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020.0
-HighT-Molten-Salt-store,investment,94107.5489,EUR/MWh,"Viswanathan_2022, p.98 (p.120)","{'carrier': ['salthight'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['SB and BOS 0.85 of 2021 value']}",2020.0
-HighT-Molten-Salt-store,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['salthight'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Hydrogen fuel cell (passenger cars),FOM,1.1,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (passenger cars),2020.0
-Hydrogen fuel cell (passenger cars),efficiency,0.48,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (passenger cars),2020.0
-Hydrogen fuel cell (passenger cars),investment,33226.0,EUR/PKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (passenger cars),2020.0
-Hydrogen fuel cell (passenger cars),lifetime,15.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (passenger cars),2020.0
-Hydrogen fuel cell (trucks),FOM,13.1,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (trucks),2020.0
-Hydrogen fuel cell (trucks),efficiency,0.56,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (trucks),2020.0
-Hydrogen fuel cell (trucks),investment,116497.0,EUR/LKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (trucks),2020.0
-Hydrogen fuel cell (trucks),lifetime,15.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (trucks),2020.0
-Hydrogen-charger,FOM,0.6345,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'h2cavern'], 'technology_type': ['charger'], 'type': ['electrochemical'], 'note': ['Guesstimate, 50% on charger']}",2020.0
-Hydrogen-charger,efficiency,0.6963,per unit,"Viswanathan_2022, p.111 (p.133) include inverter 0.98 & transformer efficiency 0.98 ","{'carrier': ['elec', 'h2cavern'], 'technology_type': ['charger'], 'type': ['electrochemical'], 'note': ['Electrolyzer']}",2020.0
-Hydrogen-charger,investment,347170.8209,EUR/MW,"Viswanathan_2022, p.113 (p.135)","{'carrier': ['elec', 'h2cavern'], 'technology_type': ['charger'], 'type': ['electrochemical'], 'note': ['Electrolyzer']}",2020.0
-Hydrogen-charger,lifetime,30.0,years,"Viswanathan_2022, p.111 (p.133)","{'carrier': ['elec', 'h2cavern'], 'technology_type': ['charger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Hydrogen-discharger,FOM,0.5812,%/year,"Viswanathan_2022, NULL","{'carrier': ['h2cavern', 'elec'], 'technology_type': ['discharger'], 'type': ['electrochemical'], 'note': ['Guesstimate, 50% on discharger']}",2020.0
-Hydrogen-discharger,efficiency,0.4869,per unit,"Viswanathan_2022, p.111 (p.133) include inverter 0.98 & transformer efficiency 0.98 ","{'carrier': ['h2cavern', 'elec'], 'technology_type': ['discharger'], 'type': ['electrochemical'], 'note': ['Fuel Cell']}",2020.0
-Hydrogen-discharger,investment,379007.4464,EUR/MW,"Viswanathan_2022, p.113 (p.135)","{'carrier': ['h2cavern', 'elec'], 'technology_type': ['discharger'], 'type': ['electrochemical'], 'note': ['Fuel Cell']}",2020.0
-Hydrogen-discharger,lifetime,30.0,years,"Viswanathan_2022, p.111 (p.133)","{'carrier': ['h2cavern', 'elec'], 'technology_type': ['discharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Hydrogen-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB =(C38+C39)*0.43/4","{'carrier': ['h2cavern'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020.0
-Hydrogen-store,investment,4779.9527,EUR/MWh,"Viswanathan_2022, p.113 (p.135)","{'carrier': ['h2cavern'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['Cavern Storage']}",2020.0
-Hydrogen-store,lifetime,30.0,years,"Viswanathan_2022, p.111 (p.133)","{'carrier': ['h2cavern'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-LNG storage tank,FOM,2.0,%/year,"Guesstimate, based on H2 (l) storage tank with comparable requirements.",Currency year and technology year assumed based on publication date.,2019.0
-LNG storage tank,investment,666.634,EUR/m^3,"Hurskainen 2019, https://cris.vtt.fi/en/publications/liquid-organic-hydrogen-carriers-lohc-concept-evaluation-and-tech pg. 46 (59).",Currency year and technology year assumed based on publication date.,2019.0
-LNG storage tank,lifetime,20.0,years,"Guesstimate, based on H2 (l) storage tank with comparable requirements.",Currency year and technology year assumed based on publication date.,2019.0
-LOHC chemical,investment,2500.0,EUR/t,"Runge et al 2020, pg.7, https://papers.ssrn.com/abstract=3623514",,2020.0
-LOHC chemical,lifetime,20.0,years,"Runge et al 2020, pg.7, https://papers.ssrn.com/abstract=3623514",,2020.0
-LOHC dehydrogenation,FOM,3.0,%/year,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2015.0
-LOHC dehydrogenation,investment,53681.4988,EUR/MW_H2,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",per MW H2 (LHV). For a large plant of 1000 MW capacity. Calculated based on base CAPEX of 30 MEUR for 300 t/day capacity and a scale factor of 0.6.,2015.0
-LOHC dehydrogenation,lifetime,20.0,years,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2015.0
-LOHC dehydrogenation (small scale),FOM,3.0,%/year,"Runge et al 2020, pg.8, https://papers.ssrn.com/abstract=3623514",,2020.0
-LOHC dehydrogenation (small scale),investment,839000.0,EUR/MW_H2,"Runge et al 2020, pg.8, https://papers.ssrn.com/abstract=3623514",MW of H2 LHV. For a small plant of 0.9 MW capacity.,2020.0
-LOHC dehydrogenation (small scale),lifetime,20.0,years,"Runge et al 2020, pg.8, https://papers.ssrn.com/abstract=3623514",,2020.0
-LOHC hydrogenation,FOM,3.0,%/year,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2015.0
+HighT-Molten-Salt-charger,FOM,1.075,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'salthight'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020
+HighT-Molten-Salt-charger,efficiency,0.99,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'salthight'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020
+HighT-Molten-Salt-charger,investment,144192.2682,EUR/MW,"Georgiou_2018, Guesstimate that charge is 20% of capital costs of power components for sensible thermal storage","{'carrier': ['elec', 'salthight'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020
+HighT-Molten-Salt-charger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'salthight'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+HighT-Molten-Salt-discharger,FOM,0.2688,%/year,"Viswanathan_2022, NULL","{'carrier': ['salthight', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020
+HighT-Molten-Salt-discharger,efficiency,0.4444,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['salthight', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020
+HighT-Molten-Salt-discharger,investment,576769.073,EUR/MW,"Georgiou_2018, Guesstimate that charge is 80% of capital costs of power components for sensible thermal storage","{'carrier': ['salthight', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020
+HighT-Molten-Salt-discharger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['salthight', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+HighT-Molten-Salt-store,FOM,0.3308,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['salthight'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020
+HighT-Molten-Salt-store,investment,94107.5489,EUR/MWh,"Viswanathan_2022, p.98 (p.120)","{'carrier': ['salthight'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['SB and BOS 0.85 of 2021 value']}",2020
+HighT-Molten-Salt-store,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['salthight'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Hydrogen fuel cell (passenger cars),FOM,1.1,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (passenger cars),2020
+Hydrogen fuel cell (passenger cars),efficiency,0.48,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (passenger cars),2020
+Hydrogen fuel cell (passenger cars),investment,33226,EUR/PKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (passenger cars),2020
+Hydrogen fuel cell (passenger cars),lifetime,15,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (passenger cars),2020
+Hydrogen fuel cell (trucks),FOM,13.1,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (trucks),2020
+Hydrogen fuel cell (trucks),efficiency,0.56,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (trucks),2020
+Hydrogen fuel cell (trucks),investment,116497,EUR/LKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (trucks),2020
+Hydrogen fuel cell (trucks),lifetime,15,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Hydrogen fuel cell (trucks),2020
+Hydrogen-charger,FOM,0.6345,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'h2cavern'], 'technology_type': ['charger'], 'type': ['electrochemical'], 'note': ['Guesstimate, 50% on charger']}",2020
+Hydrogen-charger,efficiency,0.6963,per unit,"Viswanathan_2022, p.111 (p.133) include inverter 0.98 & transformer efficiency 0.98 ","{'carrier': ['elec', 'h2cavern'], 'technology_type': ['charger'], 'type': ['electrochemical'], 'note': ['Electrolyzer']}",2020
+Hydrogen-charger,investment,347170.8209,EUR/MW,"Viswanathan_2022, p.113 (p.135)","{'carrier': ['elec', 'h2cavern'], 'technology_type': ['charger'], 'type': ['electrochemical'], 'note': ['Electrolyzer']}",2020
+Hydrogen-charger,lifetime,30,years,"Viswanathan_2022, p.111 (p.133)","{'carrier': ['elec', 'h2cavern'], 'technology_type': ['charger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Hydrogen-discharger,FOM,0.5812,%/year,"Viswanathan_2022, NULL","{'carrier': ['h2cavern', 'elec'], 'technology_type': ['discharger'], 'type': ['electrochemical'], 'note': ['Guesstimate, 50% on discharger']}",2020
+Hydrogen-discharger,efficiency,0.4869,per unit,"Viswanathan_2022, p.111 (p.133) include inverter 0.98 & transformer efficiency 0.98 ","{'carrier': ['h2cavern', 'elec'], 'technology_type': ['discharger'], 'type': ['electrochemical'], 'note': ['Fuel Cell']}",2020
+Hydrogen-discharger,investment,379007.4464,EUR/MW,"Viswanathan_2022, p.113 (p.135)","{'carrier': ['h2cavern', 'elec'], 'technology_type': ['discharger'], 'type': ['electrochemical'], 'note': ['Fuel Cell']}",2020
+Hydrogen-discharger,lifetime,30,years,"Viswanathan_2022, p.111 (p.133)","{'carrier': ['h2cavern', 'elec'], 'technology_type': ['discharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Hydrogen-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB =(C38+C39)*0.43/4","{'carrier': ['h2cavern'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020
+Hydrogen-store,investment,4779.9527,EUR/MWh,"Viswanathan_2022, p.113 (p.135)","{'carrier': ['h2cavern'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['Cavern Storage']}",2020
+Hydrogen-store,lifetime,30,years,"Viswanathan_2022, p.111 (p.133)","{'carrier': ['h2cavern'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+LNG storage tank,FOM,2,%/year,"Guesstimate, based on H2 (l) storage tank with comparable requirements.",Currency year and technology year assumed based on publication date.,2019
+LNG storage tank,investment,666.634,EUR/m^3,"Hurskainen 2019, https://cris.vtt.fi/en/publications/liquid-organic-hydrogen-carriers-lohc-concept-evaluation-and-tech pg. 46 (59).",Currency year and technology year assumed based on publication date.,2019
+LNG storage tank,lifetime,20,years,"Guesstimate, based on H2 (l) storage tank with comparable requirements.",Currency year and technology year assumed based on publication date.,2019
+LOHC chemical,investment,2500,EUR/t,"Runge et al 2020, pg.7, https://papers.ssrn.com/abstract=3623514",,2020
+LOHC chemical,lifetime,20,years,"Runge et al 2020, pg.7, https://papers.ssrn.com/abstract=3623514",,2020
+LOHC dehydrogenation,FOM,3,%/year,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2015
+LOHC dehydrogenation,investment,53681.4988,EUR/MW_H2,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",per MW H2 (LHV). For a large plant of 1000 MW capacity. Calculated based on base CAPEX of 30 MEUR for 300 t/day capacity and a scale factor of 0.6.,2015
+LOHC dehydrogenation,lifetime,20,years,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2015
+LOHC dehydrogenation (small scale),FOM,3,%/year,"Runge et al 2020, pg.8, https://papers.ssrn.com/abstract=3623514",,2020
+LOHC dehydrogenation (small scale),investment,839000,EUR/MW_H2,"Runge et al 2020, pg.8, https://papers.ssrn.com/abstract=3623514",MW of H2 LHV. For a small plant of 0.9 MW capacity.,2020
+LOHC dehydrogenation (small scale),lifetime,20,years,"Runge et al 2020, pg.8, https://papers.ssrn.com/abstract=3623514",,2020
+LOHC hydrogenation,FOM,3,%/year,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2015
 LOHC hydrogenation,electricity-input,0.004,MWh_el/t_HLOHC,Niermann et al. (2019): (https://doi.org/10.1039/C8EE02700E). 6A .,"Flow in figures shows 0.2 MW for 114 MW_HHV = 96.4326 MW_LHV = 2.89298 t hydrogen. At 5.6 wt-% effective H2 storage for loaded LOHC (H18-DBT, HLOHC), corresponds to 51.6604 t loaded LOHC .",
 LOHC hydrogenation,hydrogen-input,1.867,MWh_H2/t_HLOHC,"Runge et al 2020, pg. 7, https://papers.ssrn.com/abstract=3623514",Considering 5.6 wt-% H2 in loaded LOHC (HLOHC) and LHV of H2.,
-LOHC hydrogenation,investment,54243.958,EUR/MW_H2,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",per MW H2 (LHV). For a large plant of 2000 MW capacity. Calculated based on base CAPEX of 40 MEUR for 300 t/day capacity and a scale factor of 0.6.,2015.0
-LOHC hydrogenation,lifetime,20.0,years,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2015.0
+LOHC hydrogenation,investment,54243.958,EUR/MW_H2,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",per MW H2 (LHV). For a large plant of 2000 MW capacity. Calculated based on base CAPEX of 40 MEUR for 300 t/day capacity and a scale factor of 0.6.,2015
+LOHC hydrogenation,lifetime,20,years,"Reuß et al 2017, https://doi.org/10.1016/j.apenergy.2017.05.050 , Table 9.",,2015
 LOHC hydrogenation,lohc-input,0.944,t_LOHC/t_HLOHC,"Runge et al 2020, pg. 7, https://papers.ssrn.com/abstract=3623514","Loaded LOHC (H18-DBT, HLOHC) has loaded only 5.6%-wt H2 as rate of discharge is kept at ca. 90%.",
-LOHC loaded DBT storage,FOM,6.25,%/year,,"Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared.",2012.0
-LOHC loaded DBT storage,investment,151.5383,EUR/t,"Density via Wissenschaftliche Dienste des Deutschen Bundestages 2020, https://www.bundestag.de/resource/blob/816048/454e182d5956d45a664da9eb85486f76/WD-8-058-20-pdf-data.pdf , pg. 11.","Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared. Density of loaded LOHC H18-DBT is 0.91 t/m^3.",2012.0
-LOHC loaded DBT storage,lifetime,30.0,years,,"Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared.",2012.0
-LOHC transport ship,FOM,5.0,%/year,"Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514",,2020.0
-LOHC transport ship,capacity,75000.0,t_LOHC,"Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514",,2020.0
-LOHC transport ship,investment,35000000.0,EUR,"Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514",,2020.0
-LOHC transport ship,lifetime,15.0,years,"Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514",,2020.0
-LOHC unloaded DBT storage,FOM,6.25,%/year,,"Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared.",2012.0
-LOHC unloaded DBT storage,investment,134.2745,EUR/t,"Density via Wissenschaftliche Dienste des Deutschen Bundestages 2020, https://www.bundestag.de/resource/blob/816048/454e182d5956d45a664da9eb85486f76/WD-8-058-20-pdf-data.pdf , pg. 11.","Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared. Density of loaded LOHC H18-DBT is 0.91 t/m^3, density of unloaded LOHC H0-DBT is 1.04 t/m^3 but unloading is only to 90% (depth-of-discharge), assume density via linearisation of 1.027 t/m^3.",2012.0
-LOHC unloaded DBT storage,lifetime,30.0,years,,"Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared.",2012.0
-Lead-Acid-bicharger,FOM,2.4427,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['elec', 'lead', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['30% assumed of power components every 10 years']}",2020.0
-Lead-Acid-bicharger,efficiency,0.8832,per unit,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['elec', 'lead', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['AC-AC efficiency at transformer level 0.78^0.5']}",2020.0
-Lead-Acid-bicharger,investment,128853.6139,EUR/MW,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['elec', 'lead', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020.0
-Lead-Acid-bicharger,lifetime,12.0,years,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['elec', 'lead', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Lead-Acid-store,FOM,0.2542,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['lead'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['0.43 % of SB']}",2020.0
-Lead-Acid-store,investment,320631.3818,EUR/MWh,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['lead'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020.0
-Lead-Acid-store,lifetime,12.0,years,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['lead'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Liquid fuels ICE (passenger cars),FOM,1.6,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (passenger cars),2020.0
-Liquid fuels ICE (passenger cars),efficiency,0.215,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (passenger cars),2020.0
-Liquid fuels ICE (passenger cars),investment,24999.0,EUR/PKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (passenger cars),2020.0
-Liquid fuels ICE (passenger cars),lifetime,15.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (passenger cars),2020.0
-Liquid fuels ICE (trucks),FOM,17.1,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (trucks),2020.0
-Liquid fuels ICE (trucks),efficiency,0.373,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (trucks),2020.0
-Liquid fuels ICE (trucks),investment,105315.0,EUR/LKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (trucks),2020.0
-Liquid fuels ICE (trucks),lifetime,15.0,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (trucks),2020.0
-Liquid-Air-charger,FOM,0.366,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'lair'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020.0
-Liquid-Air-charger,efficiency,0.99,per unit,"Viswanathan_2022, NULL","{'carrier': ['elec', 'lair'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Liquid-Air-charger,investment,475721.2289,EUR/MW,"Georgiou_2018, Figure 9 of reference roughly 80% of capital cost are power related 47%/80% of costs are required for liquefaction (charging)","{'carrier': ['elec', 'lair'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020.0
-Liquid-Air-charger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'lair'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Liquid-Air-discharger,FOM,0.5212,%/year,"Viswanathan_2022, NULL","{'carrier': ['lair', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020.0
-Liquid-Air-discharger,efficiency,0.55,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['lair', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE 0.545 assume 99% for charge and other for discharge']}",2020.0
-Liquid-Air-discharger,investment,334017.033,EUR/MW,"Georgiou_2018, NULL","{'carrier': ['lair', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020.0
-Liquid-Air-discharger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['lair', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Liquid-Air-store,FOM,0.3208,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['lair'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020.0
-Liquid-Air-store,investment,159004.771,EUR/MWh,"Viswanathan_2022, p.98 (p.120)","{'carrier': ['lair'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['Liquid Air SB and BOS']}",2020.0
-Liquid-Air-store,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['lair'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Lithium-Ion-LFP-bicharger,FOM,2.1198,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['elec', 'lfp', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['30% assumed of power components every 10 years']}",2020.0
-Lithium-Ion-LFP-bicharger,efficiency,0.9193,per unit,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'lfp', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['AC-AC efficiency at transformer level 0.8452^0.5']}",2020.0
-Lithium-Ion-LFP-bicharger,investment,81553.4846,EUR/MW,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'lfp', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020.0
-Lithium-Ion-LFP-bicharger,lifetime,16.0,years,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'lfp', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Lithium-Ion-LFP-store,FOM,0.0447,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['lfp'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['0.43 % of SB']}",2020.0
-Lithium-Ion-LFP-store,investment,236482.8109,EUR/MWh,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['lfp'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020.0
-Lithium-Ion-LFP-store,lifetime,16.0,years,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['lfp'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Lithium-Ion-NMC-bicharger,FOM,2.1198,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['elec', 'nmc', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['30% assumed of power components every 10 years']}",2020.0
-Lithium-Ion-NMC-bicharger,efficiency,0.9193,per unit,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'nmc', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['AC-AC efficiency at transformer level 0.8452^0.5']}",2020.0
-Lithium-Ion-NMC-bicharger,investment,81553.4846,EUR/MW,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'nmc', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020.0
-Lithium-Ion-NMC-bicharger,lifetime,13.0,years,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'nmc', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Lithium-Ion-NMC-store,FOM,0.038,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['nmc'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['0.43 % of SB']}",2020.0
-Lithium-Ion-NMC-store,investment,269576.8493,EUR/MWh,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['nmc'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020.0
-Lithium-Ion-NMC-store,lifetime,13.0,years,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['nmc'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-LowT-Molten-Salt-charger,FOM,1.075,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'saltlowt'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020.0
-LowT-Molten-Salt-charger,efficiency,0.99,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'saltlowt'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020.0
-LowT-Molten-Salt-charger,investment,144192.2682,EUR/MW,"Georgiou_2018, Guesstimate that charge is 20% of capital costs of power components for sensible thermal storage","{'carrier': ['elec', 'saltlowt'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020.0
-LowT-Molten-Salt-charger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'saltlowt'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-LowT-Molten-Salt-discharger,FOM,0.2688,%/year,"Viswanathan_2022, NULL","{'carrier': ['saltlowt', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020.0
-LowT-Molten-Salt-discharger,efficiency,0.5394,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['saltlowt', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020.0
-LowT-Molten-Salt-discharger,investment,576769.073,EUR/MW,"Georgiou_2018, Guesstimate that charge is 80% of capital costs of power components for sensible thermal storage","{'carrier': ['saltlowt', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020.0
-LowT-Molten-Salt-discharger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['saltlowt', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-LowT-Molten-Salt-store,FOM,0.3308,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['saltlowt'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020.0
-LowT-Molten-Salt-store,investment,58041.2003,EUR/MWh,"Viswanathan_2022, p.98 (p.120)","{'carrier': ['saltlowt'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['SB and BOS 0.85 of 2021 value']}",2020.0
-LowT-Molten-Salt-store,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['saltlowt'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-MeOH transport ship,FOM,5.0,%/year,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020.0
-MeOH transport ship,capacity,75000.0,t_MeOH,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020.0
-MeOH transport ship,investment,35000000.0,EUR,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020.0
-MeOH transport ship,lifetime,15.0,years,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020.0
-Methanol steam reforming,FOM,4.0,%/year,"Niermann et al. (2021): Liquid Organic Hydrogen Carriers and alternatives for international transport of renewable hydrogen (https://doi.org/10.1016/j.rser.2020.110171), table 4.",,2020.0
-Methanol steam reforming,investment,18016.8665,EUR/MW_H2,"Niermann et al. (2021): Liquid Organic Hydrogen Carriers and alternatives for international transport of renewable hydrogen (https://doi.org/10.1016/j.rser.2020.110171), table 4.","For high temperature steam reforming plant with a capacity of 200 MW_H2 output (6t/h). Reference plant of 1 MW (30kg_H2/h) costs 150kEUR, scale factor of 0.6 assumed.",2020.0
-Methanol steam reforming,lifetime,20.0,years,"Niermann et al. (2021): Liquid Organic Hydrogen Carriers and alternatives for international transport of renewable hydrogen (https://doi.org/10.1016/j.rser.2020.110171), table 4.",,2020.0
+LOHC loaded DBT storage,FOM,6.25,%/year,,"Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared.",2012
+LOHC loaded DBT storage,investment,151.5383,EUR/t,"Density via Wissenschaftliche Dienste des Deutschen Bundestages 2020, https://www.bundestag.de/resource/blob/816048/454e182d5956d45a664da9eb85486f76/WD-8-058-20-pdf-data.pdf , pg. 11.","Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared. Density of loaded LOHC H18-DBT is 0.91 t/m^3.",2012
+LOHC loaded DBT storage,lifetime,30,years,,"Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared.",2012
+LOHC transport ship,FOM,5,%/year,"Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514",,2020
+LOHC transport ship,capacity,75000,t_LOHC,"Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514",,2020
+LOHC transport ship,investment,35000000,EUR,"Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514",,2020
+LOHC transport ship,lifetime,15,years,"Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514",,2020
+LOHC unloaded DBT storage,FOM,6.25,%/year,,"Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared.",2012
+LOHC unloaded DBT storage,investment,134.2745,EUR/t,"Density via Wissenschaftliche Dienste des Deutschen Bundestages 2020, https://www.bundestag.de/resource/blob/816048/454e182d5956d45a664da9eb85486f76/WD-8-058-20-pdf-data.pdf , pg. 11.","Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared. Density of loaded LOHC H18-DBT is 0.91 t/m^3, density of unloaded LOHC H0-DBT is 1.04 t/m^3 but unloading is only to 90% (depth-of-discharge), assume density via linearisation of 1.027 t/m^3.",2012
+LOHC unloaded DBT storage,lifetime,30,years,,"Based on storage “General liquid hydrocarbon storage (crude)”, as similar properties are shared.",2012
+Lead-Acid-bicharger,FOM,2.4427,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['elec', 'lead', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['30% assumed of power components every 10 years']}",2020
+Lead-Acid-bicharger,efficiency,0.8832,per unit,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['elec', 'lead', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['AC-AC efficiency at transformer level 0.78^0.5']}",2020
+Lead-Acid-bicharger,investment,128853.6139,EUR/MW,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['elec', 'lead', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020
+Lead-Acid-bicharger,lifetime,12,years,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['elec', 'lead', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Lead-Acid-store,FOM,0.2542,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['lead'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['0.43 % of SB']}",2020
+Lead-Acid-store,investment,320631.3818,EUR/MWh,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['lead'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020
+Lead-Acid-store,lifetime,12,years,"Viswanathan_2022, p.33 (p.55)","{'carrier': ['lead'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Liquid fuels ICE (passenger cars),FOM,1.6,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (passenger cars),2020
+Liquid fuels ICE (passenger cars),efficiency,0.215,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (passenger cars),2020
+Liquid fuels ICE (passenger cars),investment,24999,EUR/PKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (passenger cars),2020
+Liquid fuels ICE (passenger cars),lifetime,15,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (passenger cars),2020
+Liquid fuels ICE (trucks),FOM,17.1,%,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (trucks),2020
+Liquid fuels ICE (trucks),efficiency,0.373,per unit,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (trucks),2020
+Liquid fuels ICE (trucks),investment,105315,EUR/LKW,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (trucks),2020
+Liquid fuels ICE (trucks),lifetime,15,years,PATHS TO A CLIMATE-NEUTRAL ENERGY SYSTEM The German energy transformation in its social context. https://www.ise.fraunhofer.de/en/publications/studies/paths-to-a-climate-neutral-energy-system.html,Liquid fuels ICE (trucks),2020
+Liquid-Air-charger,FOM,0.366,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'lair'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020
+Liquid-Air-charger,efficiency,0.99,per unit,"Viswanathan_2022, NULL","{'carrier': ['elec', 'lair'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Liquid-Air-charger,investment,475721.2289,EUR/MW,"Georgiou_2018, Figure 9 of reference roughly 80% of capital cost are power related 47%/80% of costs are required for liquefaction (charging)","{'carrier': ['elec', 'lair'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020
+Liquid-Air-charger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'lair'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Liquid-Air-discharger,FOM,0.5212,%/year,"Viswanathan_2022, NULL","{'carrier': ['lair', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020
+Liquid-Air-discharger,efficiency,0.55,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['lair', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE 0.545 assume 99% for charge and other for discharge']}",2020
+Liquid-Air-discharger,investment,334017.033,EUR/MW,"Georgiou_2018, NULL","{'carrier': ['lair', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020
+Liquid-Air-discharger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['lair', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Liquid-Air-store,FOM,0.3208,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['lair'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020
+Liquid-Air-store,investment,159004.771,EUR/MWh,"Viswanathan_2022, p.98 (p.120)","{'carrier': ['lair'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['Liquid Air SB and BOS']}",2020
+Liquid-Air-store,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['lair'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Lithium-Ion-LFP-bicharger,FOM,2.1198,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['elec', 'lfp', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['30% assumed of power components every 10 years']}",2020
+Lithium-Ion-LFP-bicharger,efficiency,0.9193,per unit,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'lfp', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['AC-AC efficiency at transformer level 0.8452^0.5']}",2020
+Lithium-Ion-LFP-bicharger,investment,81553.4846,EUR/MW,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'lfp', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020
+Lithium-Ion-LFP-bicharger,lifetime,16,years,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'lfp', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Lithium-Ion-LFP-store,FOM,0.0447,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['lfp'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['0.43 % of SB']}",2020
+Lithium-Ion-LFP-store,investment,236482.8109,EUR/MWh,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['lfp'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020
+Lithium-Ion-LFP-store,lifetime,16,years,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['lfp'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Lithium-Ion-NMC-bicharger,FOM,2.1198,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['elec', 'nmc', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['30% assumed of power components every 10 years']}",2020
+Lithium-Ion-NMC-bicharger,efficiency,0.9193,per unit,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'nmc', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['AC-AC efficiency at transformer level 0.8452^0.5']}",2020
+Lithium-Ion-NMC-bicharger,investment,81553.4846,EUR/MW,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'nmc', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020
+Lithium-Ion-NMC-bicharger,lifetime,13,years,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['elec', 'nmc', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Lithium-Ion-NMC-store,FOM,0.038,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['nmc'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['0.43 % of SB']}",2020
+Lithium-Ion-NMC-store,investment,269576.8493,EUR/MWh,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['nmc'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020
+Lithium-Ion-NMC-store,lifetime,13,years,"Viswanathan_2022, p.24 (p.46)","{'carrier': ['nmc'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+LowT-Molten-Salt-charger,FOM,1.075,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'saltlowt'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020
+LowT-Molten-Salt-charger,efficiency,0.99,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'saltlowt'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020
+LowT-Molten-Salt-charger,investment,144192.2682,EUR/MW,"Georgiou_2018, Guesstimate that charge is 20% of capital costs of power components for sensible thermal storage","{'carrier': ['elec', 'saltlowt'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020
+LowT-Molten-Salt-charger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'saltlowt'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+LowT-Molten-Salt-discharger,FOM,0.2688,%/year,"Viswanathan_2022, NULL","{'carrier': ['saltlowt', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020
+LowT-Molten-Salt-discharger,efficiency,0.5394,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['saltlowt', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020
+LowT-Molten-Salt-discharger,investment,576769.073,EUR/MW,"Georgiou_2018, Guesstimate that charge is 80% of capital costs of power components for sensible thermal storage","{'carrier': ['saltlowt', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020
+LowT-Molten-Salt-discharger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['saltlowt', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+LowT-Molten-Salt-store,FOM,0.3308,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['saltlowt'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020
+LowT-Molten-Salt-store,investment,58041.2003,EUR/MWh,"Viswanathan_2022, p.98 (p.120)","{'carrier': ['saltlowt'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['SB and BOS 0.85 of 2021 value']}",2020
+LowT-Molten-Salt-store,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['saltlowt'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020
+MeOH transport ship,FOM,5,%/year,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020
+MeOH transport ship,capacity,75000,t_MeOH,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020
+MeOH transport ship,investment,35000000,EUR,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020
+MeOH transport ship,lifetime,15,years,"Assume comparable tanker as for LOHC transport above, c.f. Runge et al 2020, Table 10, https://papers.ssrn.com/abstract=3623514 .",,2020
+Methanol steam reforming,FOM,4,%/year,"Niermann et al. (2021): Liquid Organic Hydrogen Carriers and alternatives for international transport of renewable hydrogen (https://doi.org/10.1016/j.rser.2020.110171), table 4.",,2020
+Methanol steam reforming,investment,18016.8665,EUR/MW_H2,"Niermann et al. (2021): Liquid Organic Hydrogen Carriers and alternatives for international transport of renewable hydrogen (https://doi.org/10.1016/j.rser.2020.110171), table 4.","For high temperature steam reforming plant with a capacity of 200 MW_H2 output (6t/h). Reference plant of 1 MW (30kg_H2/h) costs 150kEUR, scale factor of 0.6 assumed.",2020
+Methanol steam reforming,lifetime,20,years,"Niermann et al. (2021): Liquid Organic Hydrogen Carriers and alternatives for international transport of renewable hydrogen (https://doi.org/10.1016/j.rser.2020.110171), table 4.",,2020
 Methanol steam reforming,methanol-input,1.201,MWh_MeOH/MWh_H2,"Niermann et al. (2021): Liquid Organic Hydrogen Carriers and alternatives for international transport of renewable hydrogen (https://doi.org/10.1016/j.rser.2020.110171), table 4.",Assuming per 1 t_H2 (with LHV 33.3333 MWh/t): 4.5 MWh_th and 3.2 MWh_el are required. We assume electricity can be substituted / provided with 1:1 as heat energy.,
-NH3 (l) storage tank incl. liquefaction,FOM,2.0,%/year,"Guesstimate, based on H2 (l) storage tank.",,2010.0
+NH3 (l) storage tank incl. liquefaction,FOM,2,%/year,"Guesstimate, based on H2 (l) storage tank.",,2010
 NH3 (l) storage tank incl. liquefaction,investment,166.8201,EUR/MWh_NH3,"Calculated based on Morgan E. 2013: doi:10.7275/11KT-3F59 , Fig. 55, Fig 58.","Based on estimated for a double-wall liquid ammonia tank (~ambient pressure, -33°C), inner tank from stainless steel, outer tank from concrete including installations for liquefaction/condensation, boil-off gas recovery and safety installations; the necessary installations make only a small fraction of the total cost. The total cost are driven by material and working time on the tanks.
 While the costs do not scale strictly linearly, we here assume they do (good approximation c.f. ref. Fig 55.) and take the costs for a 9 kt NH3 (l) tank = 8 M$2010, which is smaller 4-5x smaller than the largest deployed tanks today.
 We assume an exchange rate of 1.17$ to 1 €.
-The investment value is given per MWh NH3 store capacity, using the LHV of NH3 of 5.18 MWh/t.",2010.0
-NH3 (l) storage tank incl. liquefaction,lifetime,20.0,years,"Morgan E. 2013: doi:10.7275/11KT-3F59 , pg. 290",,2010.0
-NH3 (l) transport ship,FOM,4.0,%/year,"Cihlar et al 2020 based on IEA 2019, Table 3-B",,2019.0
-NH3 (l) transport ship,capacity,53000.0,t_NH3,"Cihlar et al 2020 based on IEA 2019, Table 3-B",,2019.0
-NH3 (l) transport ship,investment,81164200.0,EUR,"Cihlar et al 2020 based on IEA 2019, Table 3-B",,2019.0
-NH3 (l) transport ship,lifetime,20.0,years,"Guess estimated based on H2 (l) tanker, but more mature technology",,2019.0
-Ni-Zn-bicharger,FOM,2.1198,%/year,"Viswanathan_2022, p.51-52 in  section 4.4.2","{'carrier': ['elec', 'nizn', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Guesstimate 30% assumed of power components every 10 years ']}",2020.0
-Ni-Zn-bicharger,efficiency,0.9,per unit,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'nizn', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['((0.75-0.87)/2)^0.5 mean value of range efficiency is not RTE but single way AC-store conversion']}",2020.0
-Ni-Zn-bicharger,investment,81553.4846,EUR/MW,"Viswanathan_2022, p.59 (p.81) same as Li-LFP","{'carrier': ['elec', 'nizn', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020.0
-Ni-Zn-bicharger,lifetime,15.0,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'nizn', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Ni-Zn-store,FOM,0.2262,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['nizn'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020.0
-Ni-Zn-store,investment,267837.874,EUR/MWh,"Viswanathan_2022, p.59 (p.81) Table 4.14","{'carrier': ['nizn'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020.0
-Ni-Zn-store,lifetime,15.0,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['nizn'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-OCGT,FOM,1.7795,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",52 OCGT - Natural gas:  Fixed O&M,2015.0
-OCGT,VOM,4.762,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",52 OCGT - Natural gas:  Variable O&M,2015.0
-OCGT,efficiency,0.41,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","52 OCGT - Natural gas:  Electricity efficiency, annual average",2015.0
-OCGT,investment,460.5804,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",52 OCGT - Natural gas:  Specific investment,2015.0
-OCGT,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",52 OCGT - Natural gas:  Technical lifetime,2015.0
-PHS,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-PHS,efficiency,0.75,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-PHS,investment,2274.8177,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
-PHS,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
-Pumped-Heat-charger,FOM,0.366,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'phes'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020.0
-Pumped-Heat-charger,efficiency,0.99,per unit,"Viswanathan_2022, NULL","{'carrier': ['elec', 'phes'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Charger']}",2020.0
-Pumped-Heat-charger,investment,761782.6727,EUR/MW,"Georgiou_2018, Figure 9 of reference roughly 80% of capital cost are power related 47%/80% of costs are required for liquefaction (charging)","{'carrier': ['elec', 'phes'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020.0
-Pumped-Heat-charger,lifetime,33.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'phes'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Pumped-Heat-discharger,FOM,0.5212,%/year,"Viswanathan_2022, NULL","{'carrier': ['phes', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020.0
-Pumped-Heat-discharger,efficiency,0.63,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['phes', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE 0.62 assume 99% for charge and other for discharge']}",2020.0
-Pumped-Heat-discharger,investment,534868.6851,EUR/MW,"Georgiou_2018, NULL","{'carrier': ['phes', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020.0
-Pumped-Heat-discharger,lifetime,33.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['phes', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Pumped-Heat-store,FOM,0.1528,%/year,"Viswanathan_2022, p.103 (p.125)","{'carrier': ['phes'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020.0
-Pumped-Heat-store,investment,11546.7963,EUR/MWh,"Viswanathan_2022, p.92 (p.114)","{'carrier': ['phes'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['Molten Salt based SB and BOS']}",2020.0
-Pumped-Heat-store,lifetime,33.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['phes'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Pumped-Storage-Hydro-bicharger,FOM,0.9951,%/year,"Viswanathan_2022, Figure 4.16","{'carrier': ['elec', 'phs', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Pumped-Storage-Hydro-bicharger,efficiency,0.8944,per unit,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['elec', 'phs', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level 0.8^0.5']}",2020.0
-Pumped-Storage-Hydro-bicharger,investment,1397128.4612,EUR/MW,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['elec', 'phs', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Powerhouse Construction & Infrastructure']}",2020.0
-Pumped-Storage-Hydro-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['elec', 'phs', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-Pumped-Storage-Hydro-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020.0
-Pumped-Storage-Hydro-store,investment,57074.0625,EUR/MWh,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Reservoir Construction & Infrastructure']}",2020.0
-Pumped-Storage-Hydro-store,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+The investment value is given per MWh NH3 store capacity, using the LHV of NH3 of 5.18 MWh/t.",2010
+NH3 (l) storage tank incl. liquefaction,lifetime,20,years,"Morgan E. 2013: doi:10.7275/11KT-3F59 , pg. 290",,2010
+NH3 (l) transport ship,FOM,4,%/year,"Cihlar et al 2020 based on IEA 2019, Table 3-B",,2019
+NH3 (l) transport ship,capacity,53000,t_NH3,"Cihlar et al 2020 based on IEA 2019, Table 3-B",,2019
+NH3 (l) transport ship,investment,81164200,EUR,"Cihlar et al 2020 based on IEA 2019, Table 3-B",,2019
+NH3 (l) transport ship,lifetime,20,years,"Guess estimated based on H2 (l) tanker, but more mature technology",,2019
+Ni-Zn-bicharger,FOM,2.1198,%/year,"Viswanathan_2022, p.51-52 in  section 4.4.2","{'carrier': ['elec', 'nizn', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Guesstimate 30% assumed of power components every 10 years ']}",2020
+Ni-Zn-bicharger,efficiency,0.9,per unit,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'nizn', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['((0.75-0.87)/2)^0.5 mean value of range efficiency is not RTE but single way AC-store conversion']}",2020
+Ni-Zn-bicharger,investment,81553.4846,EUR/MW,"Viswanathan_2022, p.59 (p.81) same as Li-LFP","{'carrier': ['elec', 'nizn', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020
+Ni-Zn-bicharger,lifetime,15,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'nizn', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Ni-Zn-store,FOM,0.2262,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['nizn'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020
+Ni-Zn-store,investment,267837.874,EUR/MWh,"Viswanathan_2022, p.59 (p.81) Table 4.14","{'carrier': ['nizn'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020
+Ni-Zn-store,lifetime,15,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['nizn'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+OCGT,FOM,1.7795,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",52 OCGT - Natural gas:  Fixed O&M,2015
+OCGT,VOM,4.762,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",52 OCGT - Natural gas:  Variable O&M,2015
+OCGT,efficiency,0.41,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","52 OCGT - Natural gas:  Electricity efficiency, annual average",2015
+OCGT,investment,460.5804,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",52 OCGT - Natural gas:  Specific investment,2015
+OCGT,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",52 OCGT - Natural gas:  Technical lifetime,2015
+PHS,FOM,1,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+PHS,efficiency,0.75,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+PHS,investment,2274.8177,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010
+PHS,lifetime,80,years,IEA2010, from old pypsa cost assumptions,2015
+Pumped-Heat-charger,FOM,0.366,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'phes'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020
+Pumped-Heat-charger,efficiency,0.99,per unit,"Viswanathan_2022, NULL","{'carrier': ['elec', 'phes'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Charger']}",2020
+Pumped-Heat-charger,investment,761782.6727,EUR/MW,"Georgiou_2018, Figure 9 of reference roughly 80% of capital cost are power related 47%/80% of costs are required for liquefaction (charging)","{'carrier': ['elec', 'phes'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020
+Pumped-Heat-charger,lifetime,33,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'phes'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Pumped-Heat-discharger,FOM,0.5212,%/year,"Viswanathan_2022, NULL","{'carrier': ['phes', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020
+Pumped-Heat-discharger,efficiency,0.63,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['phes', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE 0.62 assume 99% for charge and other for discharge']}",2020
+Pumped-Heat-discharger,investment,534868.6851,EUR/MW,"Georgiou_2018, NULL","{'carrier': ['phes', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020
+Pumped-Heat-discharger,lifetime,33,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['phes', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Pumped-Heat-store,FOM,0.1528,%/year,"Viswanathan_2022, p.103 (p.125)","{'carrier': ['phes'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020
+Pumped-Heat-store,investment,11546.7963,EUR/MWh,"Viswanathan_2022, p.92 (p.114)","{'carrier': ['phes'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['Molten Salt based SB and BOS']}",2020
+Pumped-Heat-store,lifetime,33,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['phes'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Pumped-Storage-Hydro-bicharger,FOM,0.9951,%/year,"Viswanathan_2022, Figure 4.16","{'carrier': ['elec', 'phs', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Pumped-Storage-Hydro-bicharger,efficiency,0.8944,per unit,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['elec', 'phs', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['AC-AC efficiency at transformer level 0.8^0.5']}",2020
+Pumped-Storage-Hydro-bicharger,investment,1397128.4612,EUR/MW,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['elec', 'phs', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['Powerhouse Construction & Infrastructure']}",2020
+Pumped-Storage-Hydro-bicharger,lifetime,60,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['elec', 'phs', 'elec'], 'technology_type': ['bicharger'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+Pumped-Storage-Hydro-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020
+Pumped-Storage-Hydro-store,investment,57074.0625,EUR/MWh,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Reservoir Construction & Infrastructure']}",2020
+Pumped-Storage-Hydro-store,lifetime,60,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020
+SMR,FOM,5,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015
 SMR,efficiency,0.76,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR,investment,522201.0492,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
-SMR,lifetime,30.0,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR,investment,522201.0492,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015
+SMR,lifetime,30,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
+SMR CC,FOM,5,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015
 SMR CC,capture_rate,0.9,EUR/MW_CH4,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",wide range: capture rates betwen 54%-90%,
 SMR CC,efficiency,0.69,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR CC,investment,605753.2171,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
-SMR CC,lifetime,30.0,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-Sand-charger,FOM,1.075,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'sand'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020.0
-Sand-charger,efficiency,0.99,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'sand'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020.0
-Sand-charger,investment,144192.2682,EUR/MW,"Georgiou_2018, Guesstimate that charge is 20% of capital costs of power components for sensible thermal storage","{'carrier': ['elec', 'sand'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020.0
-Sand-charger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'sand'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Sand-discharger,FOM,0.2688,%/year,"Viswanathan_2022, NULL","{'carrier': ['sand', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020.0
-Sand-discharger,efficiency,0.53,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['sand', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020.0
-Sand-discharger,investment,576769.073,EUR/MW,"Georgiou_2018, Guesstimate that charge is 80% of capital costs of power components for sensible thermal storage","{'carrier': ['sand', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020.0
-Sand-discharger,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['sand', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Sand-store,FOM,0.3308,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['sand'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020.0
-Sand-store,investment,6700.8517,EUR/MWh,"Viswanathan_2022, p.100 (p.122)","{'carrier': ['sand'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['SB and BOS 0.85 of 2021 value']}",2020.0
-Sand-store,lifetime,35.0,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['sand'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020.0
-Steam methane reforming,FOM,3.0,%/year,"International Energy Agency (2015): Technology Roadmap Hydrogen and Fuel Cells , table 15.",Large scale SMR facility (150-300 MW).,2015.0
-Steam methane reforming,investment,497454.611,EUR/MW_H2,"International Energy Agency (2015): Technology Roadmap Hydrogen and Fuel Cells , table 15.",Large scale SMR facility (150-300 MW). Currency conversion 1.17 USD = 1 EUR.,2015.0
-Steam methane reforming,lifetime,30.0,years,"International Energy Agency (2015): Technology Roadmap Hydrogen and Fuel Cells , table 15.",Large scale SMR facility (150-300 MW).,2015.0
+SMR CC,investment,605753.2171,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015
+SMR CC,lifetime,30,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
+Sand-charger,FOM,1.075,%/year,"Viswanathan_2022, NULL","{'carrier': ['elec', 'sand'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on charger']}",2020
+Sand-charger,efficiency,0.99,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'sand'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020
+Sand-charger,investment,144192.2682,EUR/MW,"Georgiou_2018, Guesstimate that charge is 20% of capital costs of power components for sensible thermal storage","{'carrier': ['elec', 'sand'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['Power Equipment Charge']}",2020
+Sand-charger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['elec', 'sand'], 'technology_type': ['charger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Sand-discharger,FOM,0.2688,%/year,"Viswanathan_2022, NULL","{'carrier': ['sand', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Guesstimate, 50% on discharger']}",2020
+Sand-discharger,efficiency,0.53,per unit,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['sand', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['RTE assume 99% for charge and other for discharge']}",2020
+Sand-discharger,investment,576769.073,EUR/MW,"Georgiou_2018, Guesstimate that charge is 80% of capital costs of power components for sensible thermal storage","{'carrier': ['sand', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['Power Equipment Discharge']}",2020
+Sand-discharger,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['sand', 'elec'], 'technology_type': ['discharger'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Sand-store,FOM,0.3308,%/year,"Viswanathan_2022, p 104 (p.126)","{'carrier': ['sand'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['not provided calculated as for hydrogen']}",2020
+Sand-store,investment,6700.8517,EUR/MWh,"Viswanathan_2022, p.100 (p.122)","{'carrier': ['sand'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['SB and BOS 0.85 of 2021 value']}",2020
+Sand-store,lifetime,35,years,"Viswanathan_2022, p.107 (p.129)","{'carrier': ['sand'], 'technology_type': ['store'], 'type': ['thermal'], 'note': ['NULL']}",2020
+Steam methane reforming,FOM,3,%/year,"International Energy Agency (2015): Technology Roadmap Hydrogen and Fuel Cells , table 15.",Large scale SMR facility (150-300 MW).,2015
+Steam methane reforming,investment,497454.611,EUR/MW_H2,"International Energy Agency (2015): Technology Roadmap Hydrogen and Fuel Cells , table 15.",Large scale SMR facility (150-300 MW). Currency conversion 1.17 USD = 1 EUR.,2015
+Steam methane reforming,lifetime,30,years,"International Energy Agency (2015): Technology Roadmap Hydrogen and Fuel Cells , table 15.",Large scale SMR facility (150-300 MW).,2015
 Steam methane reforming,methane-input,1.483,MWh_CH4/MWh_H2,"Keipi et al (2018): Economic analysis of hydrogen production by methane thermal decomposition (https://doi.org/10.1016/j.enconman.2017.12.063), table 2.","Large scale SMR plant producing 2.5 kg/s H2 output (assuming 33.3333 MWh/t H2 LHV), with 6.9 kg/s CH4 input (feedstock) and 2 kg/s CH4 input (energy). Neglecting water consumption.",
-"Tank&bulk, diesel",efficiency,0.462,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, diesel",2023.0
-"Tank&bulk, diesel",investment,35129312.4041,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, diesel",2023.0
-"Tank&bulk, diesel",lifetime,25.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, diesel",2023.0
-"Tank&bulk, methanol",efficiency,0.4695,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, methanol",2023.0
-"Tank&bulk, methanol",investment,36885778.0243,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, methanol",2023.0
-"Tank&bulk, methanol",lifetime,25.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, methanol",2023.0
-"Tankbulk, ammonia",efficiency,0.471,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tankbulk, ammonia",2023.0
-"Tankbulk, ammonia",investment,38642243.6445,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tankbulk, ammonia",2023.0
-"Tankbulk, ammonia",lifetime,25.0,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tankbulk, ammonia",2023.0
-Vanadium-Redox-Flow-bicharger,FOM,2.4395,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['elec', 'vanadium', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['30% assumed of power components every 10 years']}",2020.0
-Vanadium-Redox-Flow-bicharger,efficiency,0.8062,per unit,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['elec', 'vanadium', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['AC-AC efficiency at transformer level 0.65^0.5']}",2020.0
-Vanadium-Redox-Flow-bicharger,investment,129023.0526,EUR/MW,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['elec', 'vanadium', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020.0
-Vanadium-Redox-Flow-bicharger,lifetime,12.0,years,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['elec', 'vanadium', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Vanadium-Redox-Flow-store,FOM,0.2345,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['vanadium'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['0.43 % of SB']}",2020.0
-Vanadium-Redox-Flow-store,investment,258072.8586,EUR/MWh,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['vanadium'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020.0
-Vanadium-Redox-Flow-store,lifetime,12.0,years,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['vanadium'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Zn-Air-bicharger,FOM,2.4395,%/year,"Viswanathan_2022, p.51-52 in  section 4.4.2","{'carrier': ['elec', 'znair', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Guesstimate 30% assumed of power components every 10 years ']}",2020.0
-Zn-Air-bicharger,efficiency,0.7937,per unit,"Viswanathan_2022, p.59 (p.81) Table 4.25 ","{'carrier': ['elec', 'znair', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['(0.63)^0.5  efficiency is not RTE but single way AC-store conversion']}",2020.0
-Zn-Air-bicharger,investment,129023.0526,EUR/MW,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znair', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020.0
-Zn-Air-bicharger,lifetime,25.0,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znair', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Zn-Air-store,FOM,0.1654,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['znair'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020.0
-Zn-Air-store,investment,174388.0144,EUR/MWh,"Viswanathan_2022, p.48 (p.70) text below Table 4.12","{'carrier': ['znair'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020.0
-Zn-Air-store,lifetime,25.0,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['znair'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Zn-Br-Flow-bicharger,FOM,2.1198,%/year,"Viswanathan_2022, p.51-52 in  section 4.4.2","{'carrier': ['elec', 'znbrflow', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Guesstimate 30% assumed of power components every 10 years ']}",2020.0
-Zn-Br-Flow-bicharger,efficiency,0.8307,per unit,"Viswanathan_2022, p.59 (p.81) Table 4.25 ","{'carrier': ['elec', 'znbrflow', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['(0.69)^0.5  efficiency is not RTE but single way AC-store conversion']}",2020.0
-Zn-Br-Flow-bicharger,investment,81553.4846,EUR/MW,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znbrflow', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020.0
-Zn-Br-Flow-bicharger,lifetime,10.0,years,"Viswanathan_2022, p.59 (p.81) Table 4.27","{'carrier': ['elec', 'znbrflow', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Zn-Br-Flow-store,FOM,0.2576,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['znbrflow'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020.0
-Zn-Br-Flow-store,investment,412306.5947,EUR/MWh,"Viswanathan_2022, p.59 (p.81) Table 4.14","{'carrier': ['znbrflow'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020.0
-Zn-Br-Flow-store,lifetime,10.0,years,"Viswanathan_2022, p.59 (p.81) Table 4.27","{'carrier': ['znbrflow'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Zn-Br-Nonflow-bicharger,FOM,2.4395,%/year,"Viswanathan_2022, p.51-52 in  section 4.4.2","{'carrier': ['elec', 'znbr', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Guesstimate 30% assumed of power components every 10 years ']}",2020.0
-Zn-Br-Nonflow-bicharger,efficiency,0.8888,per unit,"Viswanathan_2022, p.59 (p.81) Table 4.25","{'carrier': ['elec', 'znbr', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': [' (0.79)^0.5  efficiency is not RTE but single way AC-store conversion']}",2020.0
-Zn-Br-Nonflow-bicharger,investment,129023.0526,EUR/MW,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znbr', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020.0
-Zn-Br-Nonflow-bicharger,lifetime,15.0,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znbr', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-Zn-Br-Nonflow-store,FOM,0.2244,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['znbr'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020.0
-Zn-Br-Nonflow-store,investment,239220.5823,EUR/MWh,"Viswanathan_2022, p.59 (p.81) Table 4.14","{'carrier': ['znbr'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020.0
-Zn-Br-Nonflow-store,lifetime,15.0,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['znbr'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020.0
-air separation unit,FOM,3.0,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Fixed O&M,2015.0
+"Tank&bulk, diesel",efficiency,0.462,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, diesel",2023
+"Tank&bulk, diesel",investment,35129312.4041,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, diesel",2023
+"Tank&bulk, diesel",lifetime,25,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, diesel",2023
+"Tank&bulk, methanol",efficiency,0.4695,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, methanol",2023
+"Tank&bulk, methanol",investment,36885778.0243,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, methanol",2023
+"Tank&bulk, methanol",lifetime,25,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tank&bulk, methanol",2023
+"Tankbulk, ammonia",efficiency,0.471,MWh/km,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tankbulk, ammonia",2023
+"Tankbulk, ammonia",investment,38642243.6445,EUR,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tankbulk, ammonia",2023
+"Tankbulk, ammonia",lifetime,25,years,"Danish Energy Agency, inputs/data_sheets_for_maritime_commercial_freight_and_passenger_transport.xlsx","Tankbulk, ammonia",2023
+Vanadium-Redox-Flow-bicharger,FOM,2.4395,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['elec', 'vanadium', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['30% assumed of power components every 10 years']}",2020
+Vanadium-Redox-Flow-bicharger,efficiency,0.8062,per unit,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['elec', 'vanadium', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['AC-AC efficiency at transformer level 0.65^0.5']}",2020
+Vanadium-Redox-Flow-bicharger,investment,129023.0526,EUR/MW,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['elec', 'vanadium', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020
+Vanadium-Redox-Flow-bicharger,lifetime,12,years,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['elec', 'vanadium', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Vanadium-Redox-Flow-store,FOM,0.2345,%/year,"Viswanathan_2022, p.28 (p.50)","{'carrier': ['vanadium'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['0.43 % of SB']}",2020
+Vanadium-Redox-Flow-store,investment,258072.8586,EUR/MWh,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['vanadium'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020
+Vanadium-Redox-Flow-store,lifetime,12,years,"Viswanathan_2022, p.42 (p.64)","{'carrier': ['vanadium'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Zn-Air-bicharger,FOM,2.4395,%/year,"Viswanathan_2022, p.51-52 in  section 4.4.2","{'carrier': ['elec', 'znair', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Guesstimate 30% assumed of power components every 10 years ']}",2020
+Zn-Air-bicharger,efficiency,0.7937,per unit,"Viswanathan_2022, p.59 (p.81) Table 4.25 ","{'carrier': ['elec', 'znair', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['(0.63)^0.5  efficiency is not RTE but single way AC-store conversion']}",2020
+Zn-Air-bicharger,investment,129023.0526,EUR/MW,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znair', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020
+Zn-Air-bicharger,lifetime,25,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znair', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Zn-Air-store,FOM,0.1654,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['znair'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020
+Zn-Air-store,investment,174388.0144,EUR/MWh,"Viswanathan_2022, p.48 (p.70) text below Table 4.12","{'carrier': ['znair'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020
+Zn-Air-store,lifetime,25,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['znair'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Zn-Br-Flow-bicharger,FOM,2.1198,%/year,"Viswanathan_2022, p.51-52 in  section 4.4.2","{'carrier': ['elec', 'znbrflow', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Guesstimate 30% assumed of power components every 10 years ']}",2020
+Zn-Br-Flow-bicharger,efficiency,0.8307,per unit,"Viswanathan_2022, p.59 (p.81) Table 4.25 ","{'carrier': ['elec', 'znbrflow', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['(0.69)^0.5  efficiency is not RTE but single way AC-store conversion']}",2020
+Zn-Br-Flow-bicharger,investment,81553.4846,EUR/MW,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znbrflow', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020
+Zn-Br-Flow-bicharger,lifetime,10,years,"Viswanathan_2022, p.59 (p.81) Table 4.27","{'carrier': ['elec', 'znbrflow', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Zn-Br-Flow-store,FOM,0.2576,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['znbrflow'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020
+Zn-Br-Flow-store,investment,412306.5947,EUR/MWh,"Viswanathan_2022, p.59 (p.81) Table 4.14","{'carrier': ['znbrflow'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020
+Zn-Br-Flow-store,lifetime,10,years,"Viswanathan_2022, p.59 (p.81) Table 4.27","{'carrier': ['znbrflow'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Zn-Br-Nonflow-bicharger,FOM,2.4395,%/year,"Viswanathan_2022, p.51-52 in  section 4.4.2","{'carrier': ['elec', 'znbr', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Guesstimate 30% assumed of power components every 10 years ']}",2020
+Zn-Br-Nonflow-bicharger,efficiency,0.8888,per unit,"Viswanathan_2022, p.59 (p.81) Table 4.25","{'carrier': ['elec', 'znbr', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': [' (0.79)^0.5  efficiency is not RTE but single way AC-store conversion']}",2020
+Zn-Br-Nonflow-bicharger,investment,129023.0526,EUR/MW,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znbr', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['Power Equipment']}",2020
+Zn-Br-Nonflow-bicharger,lifetime,15,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['elec', 'znbr', 'elec'], 'technology_type': ['bicharger'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+Zn-Br-Nonflow-store,FOM,0.2244,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['znbr'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['derived']}",2020
+Zn-Br-Nonflow-store,investment,239220.5823,EUR/MWh,"Viswanathan_2022, p.59 (p.81) Table 4.14","{'carrier': ['znbr'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['DC storage block']}",2020
+Zn-Br-Nonflow-store,lifetime,15,years,"Viswanathan_2022, p.59 (p.81)","{'carrier': ['znbr'], 'technology_type': ['store'], 'type': ['electrochemical'], 'note': ['NULL']}",2020
+air separation unit,FOM,3,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Fixed O&M,2015
 air separation unit,electricity-input,0.25,MWh_el/t_N2,"DEA (2022): Technology Data for Renewable Fuels (https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-renewable-fuels), p.288.","For consistency reasons use value from Danish Energy Agency. DEA also reports range of values (0.2-0.4 MWh/t_N2) on pg. 288. Other efficienices reported are even higher, e.g. 0.11 Mwh/t_N2 from Morgan (2013): Techno-Economic Feasibility Study of Ammonia Plants Powered by Offshore Wind .",
-air separation unit,investment,820676.5784,EUR/t_N2/h,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Specific investment,2015.0
-air separation unit,lifetime,30.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Technical lifetime,2015.0
-allam,VOM,2.0,EUR/MWh,Own assumption. TODO: Find better technology data and cost assumptions,,2020.0
-allam,efficiency,0.6,p.u.,Own assumption. TODO: Find better technology data and cost assumptions,,2020.0
-allam,investment,1500.0,EUR/kW,Own assumption. TODO: Find better technology data and cost assumptions,,2020.0
-allam,lifetime,30.0,years,Own assumption. TODO: Find better technology data and cost assumptions,,2020.0
-battery inverter,FOM,0.3375,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Fixed O&M,2015.0
-battery inverter,efficiency,0.96,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Round trip efficiency DC,2015.0
-battery inverter,investment,169.3155,EUR/kW,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Output capacity expansion cost investment,2015.0
-battery inverter,lifetime,10.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx, Note K.",:  Technical lifetime,2015.0
-battery storage,investment,150.2675,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Energy storage expansion cost investment,2015.0
-battery storage,lifetime,25.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Technical lifetime,2015.0
-biochar pyrolysis,FOM,3.4167,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  Fixed O&M",2020.0
-biochar pyrolysis,VOM,823.497,EUR/MWh_biochar,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  Variable O&M",2020.0
-biochar pyrolysis,efficiency-biochar,0.404,MWh_biochar/MWh_feedstock,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  efficiency biochar",2020.0
-biochar pyrolysis,efficiency-heat,0.4848,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  efficiency heat",2020.0
-biochar pyrolysis,investment,154405.68,EUR/kW_biochar,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  Specific investment",2020.0
-biochar pyrolysis,lifetime,25.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  Technical lifetime",2020.0
-biochar pyrolysis,yield-biochar,0.0582,ton biochar/MWh_feedstock,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  yield biochar",2020.0
-biodiesel crops,fuel,137.6508,EUR/MWhth,"JRC ENSPRESO ca avg for MINBIORPS1 (rape seed), ENS_BaU_GFTM",,2010.0
-bioethanol crops,fuel,82.4367,EUR/MWhth,"JRC ENSPRESO ca avg for MINBIOCRP11 (Bioethanol barley, wheat, grain maize, oats, other cereals and rye), ENS_BaU_GFTM",,2010.0
+air separation unit,investment,820676.5784,EUR/t_N2/h,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Specific investment,2015
+air separation unit,lifetime,30,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",103 Hydrogen to Ammonia:  Technical lifetime,2015
+allam,VOM,2,EUR/MWh,Own assumption. TODO: Find better technology data and cost assumptions,,2020
+allam,efficiency,0.6,p.u.,Own assumption. TODO: Find better technology data and cost assumptions,,2020
+allam,investment,1500,EUR/kW,Own assumption. TODO: Find better technology data and cost assumptions,,2020
+allam,lifetime,30,years,Own assumption. TODO: Find better technology data and cost assumptions,,2020
+battery inverter,FOM,0.3375,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Fixed O&M,2015
+battery inverter,efficiency,0.96,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Round trip efficiency DC,2015
+battery inverter,investment,169.3155,EUR/kW,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Output capacity expansion cost investment,2015
+battery inverter,lifetime,10,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx, Note K.",:  Technical lifetime,2015
+battery storage,investment,150.2675,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Energy storage expansion cost investment,2015
+battery storage,lifetime,25,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Technical lifetime,2015
+biochar pyrolysis,FOM,3.4167,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  Fixed O&M",2020
+biochar pyrolysis,VOM,823.497,EUR/MWh_biochar,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  Variable O&M",2020
+biochar pyrolysis,efficiency-biochar,0.404,MWh_biochar/MWh_feedstock,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  efficiency biochar",2020
+biochar pyrolysis,efficiency-heat,0.4848,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  efficiency heat",2020
+biochar pyrolysis,investment,154405.68,EUR/kW_biochar,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  Specific investment",2020
+biochar pyrolysis,lifetime,25,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  Technical lifetime",2020
+biochar pyrolysis,yield-biochar,0.0582,ton biochar/MWh_feedstock,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","105 Slow pyrolysis, Straw:  yield biochar",2020
+biodiesel crops,fuel,137.6508,EUR/MWhth,"JRC ENSPRESO ca avg for MINBIORPS1 (rape seed), ENS_BaU_GFTM",,2010
+bioethanol crops,fuel,82.4367,EUR/MWhth,"JRC ENSPRESO ca avg for MINBIOCRP11 (Bioethanol barley, wheat, grain maize, oats, other cereals and rye), ENS_BaU_GFTM",,2010
 biogas,CO2 stored,0.0868,tCO2/MWh_th,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
-biogas,FOM,7.7769,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Total O&M",2020.0
+biogas,FOM,7.7769,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Total O&M",2020
 biogas,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
-biogas,efficiency,1.0,per unit,Assuming input biomass is already given in biogas output,,
-biogas,fuel,62.4351,EUR/MWhth,JRC and Zappa, from old pypsa cost assumptions,2015.0
-biogas,investment,955.1865,EUR/kW,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Specific investment",2020.0
-biogas,lifetime,20.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Technical lifetime",2020.0
+biogas,efficiency,1,per unit,Assuming input biomass is already given in biogas output,,
+biogas,fuel,62.4351,EUR/MWhth,JRC and Zappa, from old pypsa cost assumptions,2015
+biogas,investment,955.1865,EUR/kW,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Specific investment",2020
+biogas,lifetime,20,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Technical lifetime",2020
 biogas CC,CO2 stored,0.0868,tCO2/MWh_th,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
-biogas CC,FOM,7.7769,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Total O&M",2020.0
+biogas CC,FOM,7.7769,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Total O&M",2020
 biogas CC,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
-biogas CC,efficiency,1.0,per unit,Assuming input biomass is already given in biogas output,,
-biogas CC,investment,955.1865,EUR/kW,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Specific investment",2020.0
-biogas CC,lifetime,20.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Technical lifetime",2020.0
-biogas manure,fuel,19.8676,EUR/MWhth,"JRC ENSPRESO ca avg for MINBIOGAS1 (manure), ENS_BaU_GFTM",,2010.0
-biogas plus hydrogen,FOM,4.0,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",99 SNG from methan. of biogas:  Fixed O&M,2020.0
-biogas plus hydrogen,VOM,3.8282,EUR/MWh_CH4,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",99 SNG from methan. of biogas:  Variable O&M,2020.0
-biogas plus hydrogen,investment,803.9304,EUR/kW_CH4,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",99 SNG from methan. of biogas:  Specific investment,2020.0
-biogas plus hydrogen,lifetime,25.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",99 SNG from methan. of biogas:  Technical lifetime,2020.0
-biogas upgrading,FOM,17.0397,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","82 Upgrading 3,000 Nm3 per h:  Fixed O&M ",2020.0
-biogas upgrading,VOM,3.6704,EUR/MWh output,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","82 Upgrading 3,000 Nm3 per h:  Variable O&M",2020.0
-biogas upgrading,investment,170.2068,EUR/kW,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","82 Upgrading 3,000 Nm3 per h:  investment (upgrading, methane redution and grid injection)",2020.0
-biogas upgrading,lifetime,20.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","82 Upgrading 3,000 Nm3 per h:  Technical lifetime",2020.0
-biomass,FOM,4.5269,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-biomass,efficiency,0.468,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-biomass,fuel,7.4076,EUR/MWhth,IEA2011b, from old pypsa cost assumptions,2015.0
-biomass,investment,2337.6116,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-biomass,lifetime,30.0,years,ECF2010 in DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-biomass CHP,FOM,3.5822,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Fixed O&M",2015.0
-biomass CHP,VOM,2.222,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Variable O&M ",2015.0
-biomass CHP,c_b,0.4564,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Cb coefficient",2015.0
-biomass CHP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Cv coefficient",2015.0
-biomass CHP,efficiency,0.3003,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Electricity efficiency, net, annual average",2015.0
-biomass CHP,efficiency-heat,0.7083,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Heat efficiency, net, annual average",2015.0
-biomass CHP,investment,3397.1862,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Nominal investment ",2015.0
-biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Technical lifetime",2015.0
-biomass CHP capture,FOM,3.0,%/year,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass CHP capture,capture_rate,0.9,per unit,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass CHP capture,compression-electricity-input,0.085,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass CHP capture,compression-heat-output,0.14,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass CHP capture,electricity-input,0.025,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass CHP capture,heat-input,0.72,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass CHP capture,heat-output,0.72,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass CHP capture,investment,2700000.0,EUR/(tCO2/h),"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass CHP capture,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020.0
-biomass EOP,FOM,3.5822,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Fixed O&M",2015.0
-biomass EOP,VOM,2.222,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Variable O&M ",2015.0
-biomass EOP,c_b,0.4564,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Cb coefficient",2015.0
-biomass EOP,c_v,1.0,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Cv coefficient",2015.0
-biomass EOP,efficiency,0.3003,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Electricity efficiency, net, annual average",2015.0
-biomass EOP,efficiency-heat,0.7083,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Heat efficiency, net, annual average",2015.0
-biomass EOP,investment,3397.1862,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Nominal investment ",2015.0
-biomass EOP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Technical lifetime",2015.0
-biomass HOP,FOM,5.7529,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw HOP:  Fixed O&M, heat output",2015.0
-biomass HOP,VOM,2.9457,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",09c Straw HOP:  Variable O&M heat output,2015.0
-biomass HOP,efficiency,1.0323,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw HOP:  Total efficiency , net, annual average",2015.0
-biomass HOP,investment,881.102,EUR/kW_th - heat output,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",09c Straw HOP:  Nominal investment ,2015.0
-biomass HOP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",09c Straw HOP:  Technical lifetime,2015.0
-biomass boiler,FOM,7.4851,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","204 Biomass boiler, automatic:  Fixed O&M",2015.0
-biomass boiler,efficiency,0.86,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","204 Biomass boiler, automatic:  Heat efficiency, annual average, net",2015.0
-biomass boiler,investment,687.1015,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","204 Biomass boiler, automatic:  Specific investment",2015.0
-biomass boiler,lifetime,20.0,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","204 Biomass boiler, automatic:  Technical lifetime",2015.0
-biomass boiler,pelletizing cost,9.0,EUR/MWh_pellets,Assumption based on doi:10.1016/j.rser.2019.109506,,2019.0
+biogas CC,efficiency,1,per unit,Assuming input biomass is already given in biogas output,,
+biogas CC,investment,955.1865,EUR/kW,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Specific investment",2020
+biogas CC,lifetime,20,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","81 Biogas, Basic plant, small:  Technical lifetime",2020
+biogas manure,fuel,19.8676,EUR/MWhth,"JRC ENSPRESO ca avg for MINBIOGAS1 (manure), ENS_BaU_GFTM",,2010
+biogas plus hydrogen,FOM,4,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",99 SNG from methan. of biogas:  Fixed O&M,2020
+biogas plus hydrogen,VOM,3.8282,EUR/MWh_CH4,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",99 SNG from methan. of biogas:  Variable O&M,2020
+biogas plus hydrogen,investment,803.9304,EUR/kW_CH4,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",99 SNG from methan. of biogas:  Specific investment,2020
+biogas plus hydrogen,lifetime,25,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",99 SNG from methan. of biogas:  Technical lifetime,2020
+biogas upgrading,FOM,17.0397,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","82 Upgrading 3,000 Nm3 per h:  Fixed O&M ",2020
+biogas upgrading,VOM,3.6704,EUR/MWh output,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","82 Upgrading 3,000 Nm3 per h:  Variable O&M",2020
+biogas upgrading,investment,170.2068,EUR/kW,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","82 Upgrading 3,000 Nm3 per h:  investment (upgrading, methane redution and grid injection)",2020
+biogas upgrading,lifetime,20,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","82 Upgrading 3,000 Nm3 per h:  Technical lifetime",2020
+biomass,FOM,4.5269,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+biomass,efficiency,0.468,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+biomass,fuel,7.4076,EUR/MWhth,IEA2011b, from old pypsa cost assumptions,2015
+biomass,investment,2337.6116,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+biomass,lifetime,30,years,ECF2010 in DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+biomass CHP,FOM,3.5822,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Fixed O&M",2015
+biomass CHP,VOM,2.222,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Variable O&M ",2015
+biomass CHP,c_b,0.4564,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Cb coefficient",2015
+biomass CHP,c_v,1,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Cv coefficient",2015
+biomass CHP,efficiency,0.3003,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Electricity efficiency, net, annual average",2015
+biomass CHP,efficiency-heat,0.7083,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Heat efficiency, net, annual average",2015
+biomass CHP,investment,3397.1862,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Nominal investment ",2015
+biomass CHP,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Technical lifetime",2015
+biomass CHP capture,FOM,3,%/year,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass CHP capture,capture_rate,0.9,per unit,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass CHP capture,compression-electricity-input,0.085,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass CHP capture,compression-heat-output,0.14,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass CHP capture,electricity-input,0.025,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass CHP capture,heat-input,0.72,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass CHP capture,heat-output,0.72,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass CHP capture,investment,2700000,EUR/(tCO2/h),"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass CHP capture,lifetime,25,years,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.a Post comb - small CHP,2020
+biomass EOP,FOM,3.5822,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Fixed O&M",2015
+biomass EOP,VOM,2.222,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Variable O&M ",2015
+biomass EOP,c_b,0.4564,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Cb coefficient",2015
+biomass EOP,c_v,1,40°C/80°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Cv coefficient",2015
+biomass EOP,efficiency,0.3003,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Electricity efficiency, net, annual average",2015
+biomass EOP,efficiency-heat,0.7083,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Heat efficiency, net, annual average",2015
+biomass EOP,investment,3397.1862,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Nominal investment ",2015
+biomass EOP,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw, Large, 40 degree:  Technical lifetime",2015
+biomass HOP,FOM,5.7529,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw HOP:  Fixed O&M, heat output",2015
+biomass HOP,VOM,2.9457,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",09c Straw HOP:  Variable O&M heat output,2015
+biomass HOP,efficiency,1.0323,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09c Straw HOP:  Total efficiency , net, annual average",2015
+biomass HOP,investment,881.102,EUR/kW_th - heat output,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",09c Straw HOP:  Nominal investment ,2015
+biomass HOP,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",09c Straw HOP:  Technical lifetime,2015
+biomass boiler,FOM,7.4851,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","204 Biomass boiler, automatic:  Fixed O&M",2015
+biomass boiler,efficiency,0.86,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","204 Biomass boiler, automatic:  Heat efficiency, annual average, net",2015
+biomass boiler,investment,687.1015,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","204 Biomass boiler, automatic:  Specific investment",2015
+biomass boiler,lifetime,20,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","204 Biomass boiler, automatic:  Technical lifetime",2015
+biomass boiler,pelletizing cost,9,EUR/MWh_pellets,Assumption based on doi:10.1016/j.rser.2019.109506,,2019
 biomass-to-methanol,C in fuel,0.4129,per unit,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
 biomass-to-methanol,C stored,0.5871,per unit,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
 biomass-to-methanol,CO2 stored,0.2153,tCO2/MWh_th,"Stoichiometric calculation, doi:10.1016/j.apenergy.2022.120016",,
-biomass-to-methanol,FOM,1.3333,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",97 Methanol from biomass gasif.:  Fixed O&M,2020.0
-biomass-to-methanol,VOM,14.4653,EUR/MWh_MeOH,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",97 Methanol from biomass gasif.:  Variable O&M,2020.0
+biomass-to-methanol,FOM,1.3333,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",97 Methanol from biomass gasif.:  Fixed O&M,2020
+biomass-to-methanol,VOM,14.4653,EUR/MWh_MeOH,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",97 Methanol from biomass gasif.:  Variable O&M,2020
 biomass-to-methanol,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
-biomass-to-methanol,efficiency,0.61,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","97 Methanol from biomass gasif.:  Methanol Output,",2020.0
-biomass-to-methanol,efficiency-electricity,0.02,MWh_e/MWh_th,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","97 Methanol from biomass gasif.:  Electricity Output,",2020.0
-biomass-to-methanol,efficiency-heat,0.22,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","97 Methanol from biomass gasif.:  District heat  Output,",2020.0
-biomass-to-methanol,investment,3106.3291,EUR/kW_MeOH,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",97 Methanol from biomass gasif.:  Specific investment,2020.0
-biomass-to-methanol,lifetime,20.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",97 Methanol from biomass gasif.:  Technical lifetime,2020.0
-cement capture,FOM,3.0,%/year,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-cement capture,capture_rate,0.9,per unit,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-cement capture,compression-electricity-input,0.085,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-cement capture,compression-heat-output,0.14,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-cement capture,electricity-input,0.022,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-cement capture,heat-input,0.72,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-cement capture,heat-output,1.54,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-cement capture,investment,2600000.0,EUR/(tCO2/h),"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-cement capture,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020.0
-central air-sourced heat pump,FOM,0.2336,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Fixed O&M",2015.0
-central air-sourced heat pump,VOM,2.6561,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Variable O&M",2015.0
-central air-sourced heat pump,efficiency,3.2,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Total efficiency, net, name plate",2015.0
-central air-sourced heat pump,investment,906.0988,EUR/kW_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Specific investment",2015.0
-central air-sourced heat pump,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Technical lifetime",2015.0
-central coal CHP,FOM,1.6316,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Fixed O&M,2015.0
-central coal CHP,VOM,3.005,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Variable O&M,2015.0
-central coal CHP,c_b,1.01,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Cb coefficient,2015.0
-central coal CHP,c_v,0.15,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Cv coefficient,2015.0
-central coal CHP,efficiency,0.52,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","01 Coal CHP:  Electricity efficiency, condensation mode, net",2015.0
-central coal CHP,investment,1968.7948,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Nominal investment,2015.0
-central coal CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Technical lifetime,2015.0
-central excess-heat-sourced heat pump,FOM,0.3504,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Fixed O&M",2015.0
-central excess-heat-sourced heat pump,VOM,2.127,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Variable O&M",2015.0
-central excess-heat-sourced heat pump,efficiency,5.3,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Total efficiency , net, annual average",2015.0
-central excess-heat-sourced heat pump,investment,604.0659,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Specific investment",2015.0
-central excess-heat-sourced heat pump,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Technical lifetime",2015.0
-central gas CHP,FOM,3.3214,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M",2015.0
-central gas CHP,VOM,4.4445,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Variable O&M",2015.0
-central gas CHP,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient",2015.0
-central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions,2015.0
-central gas CHP,efficiency,0.41,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average",2015.0
-central gas CHP,investment,592.6041,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Nominal investment",2015.0
-central gas CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Technical lifetime",2015.0
-central gas CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions,2015.0
-central gas CHP CC,FOM,3.3214,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M",2015.0
-central gas CHP CC,VOM,4.4445,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Variable O&M",2015.0
-central gas CHP CC,c_b,1.0,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient",2015.0
-central gas CHP CC,efficiency,0.41,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average",2015.0
-central gas CHP CC,investment,592.6041,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Nominal investment",2015.0
-central gas CHP CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Technical lifetime",2015.0
-central gas boiler,FOM,3.8,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",44 Natural Gas DH Only:  Fixed O&M,2015.0
-central gas boiler,VOM,1.0582,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",44 Natural Gas DH Only:  Variable O&M,2015.0
-central gas boiler,efficiency,1.04,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","44 Natural Gas DH Only:  Total efficiency , net, annual average",2015.0
-central gas boiler,investment,52.9111,EUR/kW_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",44 Natural Gas DH Only:  Nominal investment,2015.0
-central gas boiler,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",44 Natural Gas DH Only:  Technical lifetime,2015.0
-central geothermal heat source,FOM,1.4735,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Fixed O&M",2015.0
-central geothermal heat source,VOM,6.4843,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Variable O&M",2015.0
-central geothermal heat source,investment,1529.6854,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Nominal investment",2015.0
-central geothermal heat source,lifetime,30.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Technical lifetime",2015.0
-central geothermal-sourced heat pump,FOM,3.7314,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Fixed O&M",2015.0
-central geothermal-sourced heat pump,VOM,6.4843,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Variable O&M",2015.0
-central geothermal-sourced heat pump,investment,604.0659,EUR/kW_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Nominal investment",2015.0
-central geothermal-sourced heat pump,lifetime,30.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Technical lifetime",2015.0
-central ground-sourced heat pump,FOM,0.394,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Fixed O&M",2015.0
-central ground-sourced heat pump,VOM,1.3268,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Variable O&M",2015.0
-central ground-sourced heat pump,efficiency,1.73,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Total efficiency , net, annual average",2015.0
-central ground-sourced heat pump,investment,537.1533,EUR/kW_th excluding drive energy,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Nominal investment",2015.0
-central ground-sourced heat pump,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Technical lifetime",2015.0
-central hydrogen CHP,FOM,5.0,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Fixed O&M,2015.0
-central hydrogen CHP,c_b,1.25,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Cb coefficient,2015.0
-central hydrogen CHP,efficiency,0.5,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","12 LT-PEMFC CHP:  Electricity efficiency, annual average",2015.0
-central hydrogen CHP,investment,1164.0438,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Nominal investment,2015.0
-central hydrogen CHP,lifetime,10.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Technical lifetime,2015.0
-central resistive heater,FOM,1.7,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",41 Electric Boilers:  Fixed O&M,2015.0
-central resistive heater,VOM,1.0582,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",41 Electric Boilers:  Variable O&M,2015.0
-central resistive heater,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","41 Electric Boilers:  Total efficiency , net, annual average",2015.0
-central resistive heater,investment,63.4933,EUR/kW_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",41 Electric Boilers:  Nominal investment; 10/15 kV; >10 MW,2015.0
-central resistive heater,lifetime,20.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",41 Electric Boilers:  Technical lifetime,2015.0
-central solar thermal,FOM,1.4,%/year,HP, from old pypsa cost assumptions,2015.0
-central solar thermal,investment,148151.0278,EUR/1000m2,HP, from old pypsa cost assumptions,2015.0
-central solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions,2015.0
-central solid biomass CHP,FOM,2.8661,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Fixed O&M",2015.0
-central solid biomass CHP,VOM,4.8512,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Variable O&M ",2015.0
-central solid biomass CHP,c_b,0.3506,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cb coefficient",2015.0
-central solid biomass CHP,c_v,1.0,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cv coefficient",2015.0
-central solid biomass CHP,efficiency,0.2699,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Electricity efficiency, net, annual average",2015.0
-central solid biomass CHP,efficiency-heat,0.8245,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Heat efficiency, net, annual average",2015.0
-central solid biomass CHP,investment,3544.5017,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Nominal investment ",2015.0
-central solid biomass CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Technical lifetime",2015.0
-central solid biomass CHP,p_nom_ratio,1.0,per unit,, from old pypsa cost assumptions,2015.0
-central solid biomass CHP CC,FOM,2.8661,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Fixed O&M",2015.0
-central solid biomass CHP CC,VOM,4.8512,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Variable O&M ",2015.0
-central solid biomass CHP CC,c_b,0.3506,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cb coefficient",2015.0
-central solid biomass CHP CC,c_v,1.0,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cv coefficient",2015.0
-central solid biomass CHP CC,efficiency,0.2699,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Electricity efficiency, net, annual average",2015.0
-central solid biomass CHP CC,efficiency-heat,0.8245,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Heat efficiency, net, annual average",2015.0
-central solid biomass CHP CC,investment,5207.5282,EUR/kW_e,Combination of central solid biomass CHP CC and solid biomass boiler steam,,2015.0
-central solid biomass CHP CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Technical lifetime",2015.0
-central solid biomass CHP powerboost CC,FOM,2.8661,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Fixed O&M",2015.0
-central solid biomass CHP powerboost CC,VOM,4.8512,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Variable O&M ",2015.0
-central solid biomass CHP powerboost CC,c_b,0.3506,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cb coefficient",2015.0
-central solid biomass CHP powerboost CC,c_v,1.0,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cv coefficient",2015.0
-central solid biomass CHP powerboost CC,efficiency,0.2699,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Electricity efficiency, net, annual average",2015.0
-central solid biomass CHP powerboost CC,efficiency-heat,0.8245,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Heat efficiency, net, annual average",2015.0
-central solid biomass CHP powerboost CC,investment,3544.5017,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Nominal investment ",2015.0
-central solid biomass CHP powerboost CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Technical lifetime",2015.0
-central water pit charger,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Charger efficiency,2015.0
-central water pit discharger,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Discharger efficiency,2015.0
-central water pit storage,FOM,0.551,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",140 PTES seasonal:  Fixed O&M,2015.0
-central water pit storage,energy to power ratio,150.0,h,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",140 PTES seasonal:  Ratio between energy storage and input capacity,2015.0
-central water pit storage,investment,0.5761,EUR/kWhCapacity,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",140 PTES seasonal:  Specific investment,2015.0
-central water pit storage,lifetime,25.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",140 PTES seasonal:  Technical lifetime,2015.0
-central water tank charger,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Charger efficiency,2015.0
-central water tank discharger,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Discharger efficiency,2015.0
-central water tank storage,FOM,0.2901,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",141 Large hot water tank:  Fixed O&M,2015.0
-central water tank storage,energy to power ratio,60.3448,h,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",141 Large hot water tank:  Ratio between energy storage and input capacity,2015.0
-central water tank storage,investment,3.1374,EUR/kWhCapacity,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",141 Large hot water tank:  Specific investment,2015.0
-central water tank storage,lifetime,40.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",141 Large hot water tank:  Technical lifetime,2015.0
-central water-sourced heat pump,FOM,0.5,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Fixed O&M",2015.0
-central water-sourced heat pump,VOM,1.6826,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Variable O&M",2015.0
-central water-sourced heat pump,efficiency,3.82,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Total efficiency , net, annual average",2015.0
-central water-sourced heat pump,investment,1058.2216,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Specific investment",2015.0
-central water-sourced heat pump,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Technical lifetime",2015.0
-clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
-clean water tank storage,investment,69.1286,EUR/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
-clean water tank storage,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+biomass-to-methanol,efficiency,0.61,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","97 Methanol from biomass gasif.:  Methanol Output,",2020
+biomass-to-methanol,efficiency-electricity,0.02,MWh_e/MWh_th,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","97 Methanol from biomass gasif.:  Electricity Output,",2020
+biomass-to-methanol,efficiency-heat,0.22,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx","97 Methanol from biomass gasif.:  District heat  Output,",2020
+biomass-to-methanol,investment,3106.3291,EUR/kW_MeOH,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",97 Methanol from biomass gasif.:  Specific investment,2020
+biomass-to-methanol,lifetime,20,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",97 Methanol from biomass gasif.:  Technical lifetime,2020
+cement capture,FOM,3,%/year,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+cement capture,capture_rate,0.9,per unit,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+cement capture,compression-electricity-input,0.085,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+cement capture,compression-heat-output,0.14,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+cement capture,electricity-input,0.022,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+cement capture,heat-input,0.72,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+cement capture,heat-output,1.54,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+cement capture,investment,2600000,EUR/(tCO2/h),"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+cement capture,lifetime,25,years,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",401.c Post comb - Cement kiln,2020
+central air-sourced heat pump,FOM,0.2336,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Fixed O&M",2015
+central air-sourced heat pump,VOM,2.6561,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Variable O&M",2015
+central air-sourced heat pump,efficiency,3.2,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Total efficiency, net, name plate",2015
+central air-sourced heat pump,investment,906.0988,EUR/kW_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Specific investment",2015
+central air-sourced heat pump,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, airsource 3 MW:  Technical lifetime",2015
+central coal CHP,FOM,1.6316,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Fixed O&M,2015
+central coal CHP,VOM,3.005,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Variable O&M,2015
+central coal CHP,c_b,1.01,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Cb coefficient,2015
+central coal CHP,c_v,0.15,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Cv coefficient,2015
+central coal CHP,efficiency,0.52,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","01 Coal CHP:  Electricity efficiency, condensation mode, net",2015
+central coal CHP,investment,1968.7948,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Nominal investment,2015
+central coal CHP,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",01 Coal CHP:  Technical lifetime,2015
+central excess-heat-sourced heat pump,FOM,0.3504,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Fixed O&M",2015
+central excess-heat-sourced heat pump,VOM,2.127,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Variable O&M",2015
+central excess-heat-sourced heat pump,efficiency,5.3,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Total efficiency , net, annual average",2015
+central excess-heat-sourced heat pump,investment,604.0659,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Specific investment",2015
+central excess-heat-sourced heat pump,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, excess heat 10 MW:  Technical lifetime",2015
+central gas CHP,FOM,3.3214,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M",2015
+central gas CHP,VOM,4.4445,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Variable O&M",2015
+central gas CHP,c_b,1,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient",2015
+central gas CHP,c_v,0.17,per unit,DEA (loss of fuel for additional heat), from old pypsa cost assumptions,2015
+central gas CHP,efficiency,0.41,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average",2015
+central gas CHP,investment,592.6041,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Nominal investment",2015
+central gas CHP,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Technical lifetime",2015
+central gas CHP,p_nom_ratio,1,per unit,, from old pypsa cost assumptions,2015
+central gas CHP CC,FOM,3.3214,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Fixed O&M",2015
+central gas CHP CC,VOM,4.4445,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Variable O&M",2015
+central gas CHP CC,c_b,1,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Cb coefficient",2015
+central gas CHP CC,efficiency,0.41,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Electricity efficiency, annual average",2015
+central gas CHP CC,investment,592.6041,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Nominal investment",2015
+central gas CHP CC,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","04 Gas turb. simple cycle, L:  Technical lifetime",2015
+central gas boiler,FOM,3.8,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",44 Natural Gas DH Only:  Fixed O&M,2015
+central gas boiler,VOM,1.0582,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",44 Natural Gas DH Only:  Variable O&M,2015
+central gas boiler,efficiency,1.04,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","44 Natural Gas DH Only:  Total efficiency , net, annual average",2015
+central gas boiler,investment,52.9111,EUR/kW_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",44 Natural Gas DH Only:  Nominal investment,2015
+central gas boiler,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",44 Natural Gas DH Only:  Technical lifetime,2015
+central geothermal heat source,FOM,1.4735,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Fixed O&M",2015
+central geothermal heat source,VOM,6.4843,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Variable O&M",2015
+central geothermal heat source,investment,1529.6854,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Nominal investment",2015
+central geothermal heat source,lifetime,30,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Technical lifetime",2015
+central geothermal-sourced heat pump,FOM,3.7314,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Fixed O&M",2015
+central geothermal-sourced heat pump,VOM,6.4843,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Variable O&M",2015
+central geothermal-sourced heat pump,investment,604.0659,EUR/kW_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Nominal investment",2015
+central geothermal-sourced heat pump,lifetime,30,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","45.1.a Geothermal DH, 1200m, E:  Technical lifetime",2015
+central ground-sourced heat pump,FOM,0.394,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Fixed O&M",2015
+central ground-sourced heat pump,VOM,1.3268,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Variable O&M",2015
+central ground-sourced heat pump,efficiency,1.73,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Total efficiency , net, annual average",2015
+central ground-sourced heat pump,investment,537.1533,EUR/kW_th excluding drive energy,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Nominal investment",2015
+central ground-sourced heat pump,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Absorption heat pump, DH:  Technical lifetime",2015
+central hydrogen CHP,FOM,5,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Fixed O&M,2015
+central hydrogen CHP,c_b,1.25,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Cb coefficient,2015
+central hydrogen CHP,efficiency,0.5,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","12 LT-PEMFC CHP:  Electricity efficiency, annual average",2015
+central hydrogen CHP,investment,1164.0438,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Nominal investment,2015
+central hydrogen CHP,lifetime,10,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Technical lifetime,2015
+central resistive heater,FOM,1.7,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",41 Electric Boilers:  Fixed O&M,2015
+central resistive heater,VOM,1.0582,EUR/MWh_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",41 Electric Boilers:  Variable O&M,2015
+central resistive heater,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","41 Electric Boilers:  Total efficiency , net, annual average",2015
+central resistive heater,investment,63.4933,EUR/kW_th,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",41 Electric Boilers:  Nominal investment; 10/15 kV; >10 MW,2015
+central resistive heater,lifetime,20,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",41 Electric Boilers:  Technical lifetime,2015
+central solar thermal,FOM,1.4,%/year,HP, from old pypsa cost assumptions,2015
+central solar thermal,investment,148151.0278,EUR/1000m2,HP, from old pypsa cost assumptions,2015
+central solar thermal,lifetime,20,years,HP, from old pypsa cost assumptions,2015
+central solid biomass CHP,FOM,2.8661,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Fixed O&M",2015
+central solid biomass CHP,VOM,4.8512,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Variable O&M ",2015
+central solid biomass CHP,c_b,0.3506,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cb coefficient",2015
+central solid biomass CHP,c_v,1,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cv coefficient",2015
+central solid biomass CHP,efficiency,0.2699,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Electricity efficiency, net, annual average",2015
+central solid biomass CHP,efficiency-heat,0.8245,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Heat efficiency, net, annual average",2015
+central solid biomass CHP,investment,3544.5017,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Nominal investment ",2015
+central solid biomass CHP,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Technical lifetime",2015
+central solid biomass CHP,p_nom_ratio,1,per unit,, from old pypsa cost assumptions,2015
+central solid biomass CHP CC,FOM,2.8661,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Fixed O&M",2015
+central solid biomass CHP CC,VOM,4.8512,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Variable O&M ",2015
+central solid biomass CHP CC,c_b,0.3506,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cb coefficient",2015
+central solid biomass CHP CC,c_v,1,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cv coefficient",2015
+central solid biomass CHP CC,efficiency,0.2699,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Electricity efficiency, net, annual average",2015
+central solid biomass CHP CC,efficiency-heat,0.8245,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Heat efficiency, net, annual average",2015
+central solid biomass CHP CC,investment,5207.5282,EUR/kW_e,Combination of central solid biomass CHP CC and solid biomass boiler steam,,2015
+central solid biomass CHP CC,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Technical lifetime",2015
+central solid biomass CHP powerboost CC,FOM,2.8661,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Fixed O&M",2015
+central solid biomass CHP powerboost CC,VOM,4.8512,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Variable O&M ",2015
+central solid biomass CHP powerboost CC,c_b,0.3506,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cb coefficient",2015
+central solid biomass CHP powerboost CC,c_v,1,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Cv coefficient",2015
+central solid biomass CHP powerboost CC,efficiency,0.2699,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Electricity efficiency, net, annual average",2015
+central solid biomass CHP powerboost CC,efficiency-heat,0.8245,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Heat efficiency, net, annual average",2015
+central solid biomass CHP powerboost CC,investment,3544.5017,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Nominal investment ",2015
+central solid biomass CHP powerboost CC,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","09a Wood Chips, Large 50 degree:  Technical lifetime",2015
+central water pit charger,efficiency,1,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Charger efficiency,2015
+central water pit discharger,efficiency,1,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Discharger efficiency,2015
+central water pit storage,FOM,0.551,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",140 PTES seasonal:  Fixed O&M,2015
+central water pit storage,energy to power ratio,150,h,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",140 PTES seasonal:  Ratio between energy storage and input capacity,2015
+central water pit storage,investment,0.5761,EUR/kWhCapacity,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",140 PTES seasonal:  Specific investment,2015
+central water pit storage,lifetime,25,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",140 PTES seasonal:  Technical lifetime,2015
+central water tank charger,efficiency,1,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Charger efficiency,2015
+central water tank discharger,efficiency,1,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Discharger efficiency,2015
+central water tank storage,FOM,0.2901,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",141 Large hot water tank:  Fixed O&M,2015
+central water tank storage,energy to power ratio,60.3448,h,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",141 Large hot water tank:  Ratio between energy storage and input capacity,2015
+central water tank storage,investment,3.1374,EUR/kWhCapacity,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",141 Large hot water tank:  Specific investment,2015
+central water tank storage,lifetime,40,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",141 Large hot water tank:  Technical lifetime,2015
+central water-sourced heat pump,FOM,0.5,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Fixed O&M",2015
+central water-sourced heat pump,VOM,1.6826,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Variable O&M",2015
+central water-sourced heat pump,efficiency,3.82,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Total efficiency , net, annual average",2015
+central water-sourced heat pump,investment,1058.2216,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Specific investment",2015
+central water-sourced heat pump,lifetime,40,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Technical lifetime",2015
+clean water tank storage,FOM,2,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013
+clean water tank storage,investment,69.1286,EUR/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013
+clean water tank storage,lifetime,30,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
 coal,CO2 intensity,0.3361,tCO2/MWh_th,Entwicklung der spezifischen Kohlendioxid-Emissionen des deutschen Strommix in den Jahren 1990 - 2018,,
-coal,FOM,1.31,%/year,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. (39.5+91.25) USD/kW_e/a /2 / (1.09 USD/EUR) / investment cost * 100.",2023.0
-coal,VOM,3.2612,EUR/MWh_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. (3+5.5)USD/MWh_e/2 / (1.09 USD/EUR).",2023.0
-coal,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. 1 / ((8.75+12) MMbtu/MWh_th /2 / (3.4095 MMbtu/MWh_th)), rounded up.",2023.0
-coal,fuel,9.5542,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 99 USD/t.",2010.0
-coal,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR).",2023.0
-coal,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023.0
-csp-tower,FOM,1.1,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,1.0
-csp-tower,investment,108.37,"EUR/kW_th,dp",ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
-csp-tower,lifetime,30.0,years,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-,2020.0
-csp-tower TES,FOM,1.1,%/year,see solar-tower.,-,1.0
-csp-tower TES,investment,14.52,EUR/kWh_th,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
-csp-tower TES,lifetime,30.0,years,see solar-tower.,-,2020.0
-csp-tower power block,FOM,1.1,%/year,see solar-tower.,-,1.0
-csp-tower power block,investment,759.17,EUR/kW_e,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR.",2020.0
-csp-tower power block,lifetime,30.0,years,see solar-tower.,-,2020.0
-decentral CHP,FOM,3.0,%/year,HP, from old pypsa cost assumptions,2015.0
-decentral CHP,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015.0
-decentral CHP,investment,1481.5103,EUR/kWel,HP, from old pypsa cost assumptions,2015.0
-decentral CHP,lifetime,25.0,years,HP, from old pypsa cost assumptions,2015.0
-decentral air-sourced heat pump,FOM,3.0014,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.3 Air to water existing:  Fixed O&M,2015.0
-decentral air-sourced heat pump,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015.0
-decentral air-sourced heat pump,efficiency,3.6,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","207.3 Air to water existing:  Heat efficiency, annual average, net, radiators, existing one family house",2015.0
-decentral air-sourced heat pump,investment,899.4884,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.3 Air to water existing:  Specific investment,2015.0
-decentral air-sourced heat pump,lifetime,18.0,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.3 Air to water existing:  Technical lifetime,2015.0
-decentral gas boiler,FOM,6.6924,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",202 Natural gas boiler:  Fixed O&M,2015.0
-decentral gas boiler,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015.0
-decentral gas boiler,efficiency,0.98,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","202 Natural gas boiler:  Total efficiency, annual average, net",2015.0
-decentral gas boiler,investment,314.1035,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",202 Natural gas boiler:  Specific investment,2015.0
-decentral gas boiler,lifetime,20.0,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",202 Natural gas boiler:  Technical lifetime,2015.0
-decentral gas boiler connection,investment,196.3147,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",:  Possible additional specific investment,2015.0
-decentral gas boiler connection,lifetime,50.0,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",:  Technical lifetime,2015.0
-decentral ground-sourced heat pump,FOM,1.8223,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.7 Ground source existing:  Fixed O&M,2015.0
-decentral ground-sourced heat pump,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015.0
-decentral ground-sourced heat pump,efficiency,3.9,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","207.7 Ground source existing:  Heat efficiency, annual average, net, radiators, existing one family house",2015.0
-decentral ground-sourced heat pump,investment,1481.5103,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.7 Ground source existing:  Specific investment,2015.0
-decentral ground-sourced heat pump,lifetime,20.0,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.7 Ground source existing:  Technical lifetime,2015.0
-decentral oil boiler,FOM,2.0,%/year,Palzer thesis (https://energiesysteme-zukunft.de/fileadmin/user_upload/Publikationen/PDFs/ESYS_Materialien_Optimierungsmodell_REMod-D.pdf), from old pypsa cost assumptions,2015.0
-decentral oil boiler,efficiency,0.9,per unit,Palzer thesis (https://energiesysteme-zukunft.de/fileadmin/user_upload/Publikationen/PDFs/ESYS_Materialien_Optimierungsmodell_REMod-D.pdf), from old pypsa cost assumptions,2015.0
-decentral oil boiler,investment,165.0975,EUR/kWth,Palzer thesis (https://energiesysteme-zukunft.de/fileadmin/user_upload/Publikationen/PDFs/ESYS_Materialien_Optimierungsmodell_REMod-D.pdf) (+eigene Berechnung), from old pypsa cost assumptions,2015.0
-decentral oil boiler,lifetime,20.0,years,Palzer thesis (https://energiesysteme-zukunft.de/fileadmin/user_upload/Publikationen/PDFs/ESYS_Materialien_Optimierungsmodell_REMod-D.pdf), from old pypsa cost assumptions,2015.0
-decentral resistive heater,FOM,2.0,%/year,Schaber thesis, from old pypsa cost assumptions,2015.0
-decentral resistive heater,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015.0
-decentral resistive heater,efficiency,0.9,per unit,Schaber thesis, from old pypsa cost assumptions,2015.0
-decentral resistive heater,investment,105.8222,EUR/kWhth,Schaber thesis, from old pypsa cost assumptions,2015.0
-decentral resistive heater,lifetime,20.0,years,Schaber thesis, from old pypsa cost assumptions,2015.0
-decentral solar thermal,FOM,1.3,%/year,HP, from old pypsa cost assumptions,2015.0
-decentral solar thermal,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015.0
-decentral solar thermal,investment,285719.8393,EUR/1000m2,HP, from old pypsa cost assumptions,2015.0
-decentral solar thermal,lifetime,20.0,years,HP, from old pypsa cost assumptions,2015.0
-decentral water tank charger,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Charger efficiency,2015.0
-decentral water tank discharger,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Discharger efficiency,2015.0
-decentral water tank storage,FOM,1.0,%/year,HP, from old pypsa cost assumptions,2015.0
-decentral water tank storage,VOM,1.0582,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Variable O&M,2015.0
-decentral water tank storage,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015.0
-decentral water tank storage,energy to power ratio,0.15,h,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Ratio between energy storage and input capacity,2015.0
-decentral water tank storage,investment,433.8709,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Specific investment,2015.0
-decentral water tank storage,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Technical lifetime,2015.0
-digestible biomass,fuel,17.0611,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOAGRW1, ENS_Ref for 2040",,2010.0
-digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+coal,FOM,1.31,%/year,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. (39.5+91.25) USD/kW_e/a /2 / (1.09 USD/EUR) / investment cost * 100.",2023
+coal,VOM,3.2612,EUR/MWh_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. (3+5.5)USD/MWh_e/2 / (1.09 USD/EUR).",2023
+coal,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. 1 / ((8.75+12) MMbtu/MWh_th /2 / (3.4095 MMbtu/MWh_th)), rounded up.",2023
+coal,fuel,9.5542,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 99 USD/t.",2010
+coal,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR).",2023
+coal,lifetime,40,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023
+csp-tower,FOM,1.1,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,2020
+csp-tower,investment,108.37,"EUR/kW_th,dp",ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020
+csp-tower,lifetime,30,years,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-,2020
+csp-tower TES,FOM,1.1,%/year,see solar-tower.,-,2020
+csp-tower TES,investment,14.52,EUR/kWh_th,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020
+csp-tower TES,lifetime,30,years,see solar-tower.,-,2020
+csp-tower power block,FOM,1.1,%/year,see solar-tower.,-,2020
+csp-tower power block,investment,759.17,EUR/kW_e,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR.",2020
+csp-tower power block,lifetime,30,years,see solar-tower.,-,2020
+decentral CHP,FOM,3,%/year,HP, from old pypsa cost assumptions,2015
+decentral CHP,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015
+decentral CHP,investment,1481.5103,EUR/kWel,HP, from old pypsa cost assumptions,2015
+decentral CHP,lifetime,25,years,HP, from old pypsa cost assumptions,2015
+decentral air-sourced heat pump,FOM,3.0014,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.3 Air to water existing:  Fixed O&M,2015
+decentral air-sourced heat pump,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015
+decentral air-sourced heat pump,efficiency,3.6,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","207.3 Air to water existing:  Heat efficiency, annual average, net, radiators, existing one family house",2015
+decentral air-sourced heat pump,investment,899.4884,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.3 Air to water existing:  Specific investment,2015
+decentral air-sourced heat pump,lifetime,18,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.3 Air to water existing:  Technical lifetime,2015
+decentral gas boiler,FOM,6.6924,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",202 Natural gas boiler:  Fixed O&M,2015
+decentral gas boiler,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015
+decentral gas boiler,efficiency,0.98,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","202 Natural gas boiler:  Total efficiency, annual average, net",2015
+decentral gas boiler,investment,314.1035,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",202 Natural gas boiler:  Specific investment,2015
+decentral gas boiler,lifetime,20,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",202 Natural gas boiler:  Technical lifetime,2015
+decentral gas boiler connection,investment,196.3147,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",:  Possible additional specific investment,2015
+decentral gas boiler connection,lifetime,50,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",:  Technical lifetime,2015
+decentral ground-sourced heat pump,FOM,1.8223,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.7 Ground source existing:  Fixed O&M,2015
+decentral ground-sourced heat pump,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015
+decentral ground-sourced heat pump,efficiency,3.9,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","207.7 Ground source existing:  Heat efficiency, annual average, net, radiators, existing one family house",2015
+decentral ground-sourced heat pump,investment,1481.5103,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.7 Ground source existing:  Specific investment,2015
+decentral ground-sourced heat pump,lifetime,20,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",207.7 Ground source existing:  Technical lifetime,2015
+decentral oil boiler,FOM,2,%/year,Palzer thesis (https://energiesysteme-zukunft.de/fileadmin/user_upload/Publikationen/PDFs/ESYS_Materialien_Optimierungsmodell_REMod-D.pdf), from old pypsa cost assumptions,2015
+decentral oil boiler,efficiency,0.9,per unit,Palzer thesis (https://energiesysteme-zukunft.de/fileadmin/user_upload/Publikationen/PDFs/ESYS_Materialien_Optimierungsmodell_REMod-D.pdf), from old pypsa cost assumptions,2015
+decentral oil boiler,investment,165.0975,EUR/kWth,Palzer thesis (https://energiesysteme-zukunft.de/fileadmin/user_upload/Publikationen/PDFs/ESYS_Materialien_Optimierungsmodell_REMod-D.pdf) (+eigene Berechnung), from old pypsa cost assumptions,2015
+decentral oil boiler,lifetime,20,years,Palzer thesis (https://energiesysteme-zukunft.de/fileadmin/user_upload/Publikationen/PDFs/ESYS_Materialien_Optimierungsmodell_REMod-D.pdf), from old pypsa cost assumptions,2015
+decentral resistive heater,FOM,2,%/year,Schaber thesis, from old pypsa cost assumptions,2015
+decentral resistive heater,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015
+decentral resistive heater,efficiency,0.9,per unit,Schaber thesis, from old pypsa cost assumptions,2015
+decentral resistive heater,investment,105.8222,EUR/kWhth,Schaber thesis, from old pypsa cost assumptions,2015
+decentral resistive heater,lifetime,20,years,Schaber thesis, from old pypsa cost assumptions,2015
+decentral solar thermal,FOM,1.3,%/year,HP, from old pypsa cost assumptions,2015
+decentral solar thermal,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015
+decentral solar thermal,investment,285719.8393,EUR/1000m2,HP, from old pypsa cost assumptions,2015
+decentral solar thermal,lifetime,20,years,HP, from old pypsa cost assumptions,2015
+decentral water tank charger,efficiency,1,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Charger efficiency,2015
+decentral water tank discharger,efficiency,1,per unit,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Discharger efficiency,2015
+decentral water tank storage,FOM,1,%/year,HP, from old pypsa cost assumptions,2015
+decentral water tank storage,VOM,1.0582,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Variable O&M,2015
+decentral water tank storage,discount rate,0.04,per unit,Palzer thesis, from old pypsa cost assumptions,2015
+decentral water tank storage,energy to power ratio,0.15,h,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Ratio between energy storage and input capacity,2015
+decentral water tank storage,investment,433.8709,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Specific investment,2015
+decentral water tank storage,lifetime,30,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Technical lifetime,2015
+digestible biomass,fuel,17.0611,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOAGRW1, ENS_Ref for 2040",,2010
+digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014
 digestible biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 digestible biomass to hydrogen,efficiency,0.39,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
-digestible biomass to hydrogen,investment,3707.4795,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
-direct air capture,FOM,4.95,%/year,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020.0
-direct air capture,compression-electricity-input,0.15,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020.0
-direct air capture,compression-heat-output,0.2,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020.0
-direct air capture,electricity-input,0.4,MWh_el/t_CO2,"Beuttler et al (2019): The Role of Direct Air Capture in Mitigation of Antropogenic Greenhouse Gas emissions (https://doi.org/10.3389/fclim.2019.00010), alternative:  Breyer et al (2019).","0.4 MWh based on Beuttler et al (2019) for Climeworks LT DAC, alternative value: 0.182 MWh based on Breyer et al (2019). Should already include electricity for water scrubbing and compression (high quality CO2 output).",2020.0
-direct air capture,heat-input,1.6,MWh_th/t_CO2,"Beuttler et al (2019): The Role of Direct Air Capture in Mitigation of Antropogenic Greenhouse Gas emissions (https://doi.org/10.3389/fclim.2019.00010), alternative:  Breyer et al (2019).","Thermal energy demand. Provided via air-sourced heat pumps. 1.6 MWh based on Beuttler et al (2019) for Climeworks LT DAC, alternative value: 1.102 MWh based on Breyer et al (2019).",2020.0
-direct air capture,heat-output,1.0,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020.0
-direct air capture,investment,6000000.0,EUR/(tCO2/h),"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020.0
-direct air capture,lifetime,20.0,years,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020.0
-direct firing gas,FOM,1.1818,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Fixed O&M,2019.0
-direct firing gas,VOM,0.2794,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Variable O&M,2019.0
-direct firing gas,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","312.a Direct firing Natural Gas:  Total efficiency, net, annual average",2019.0
-direct firing gas,investment,15.105,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Nominal investment,2019.0
-direct firing gas,lifetime,15.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Technical lifetime,2019.0
-direct firing gas CC,FOM,1.1818,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Fixed O&M,2019.0
-direct firing gas CC,VOM,0.2794,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Variable O&M,2019.0
-direct firing gas CC,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","312.a Direct firing Natural Gas:  Total efficiency, net, annual average",2019.0
-direct firing gas CC,investment,15.105,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Nominal investment,2019.0
-direct firing gas CC,lifetime,15.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Technical lifetime,2019.0
-direct firing solid fuels,FOM,1.5,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Fixed O&M,2019.0
-direct firing solid fuels,VOM,0.3326,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Variable O&M,2019.0
-direct firing solid fuels,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","312.b Direct firing Sold Fuels:  Total efficiency, net, annual average",2019.0
-direct firing solid fuels,investment,221.54,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Nominal investment,2019.0
-direct firing solid fuels,lifetime,15.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Technical lifetime,2019.0
-direct firing solid fuels CC,FOM,1.5,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Fixed O&M,2019.0
-direct firing solid fuels CC,VOM,0.3326,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Variable O&M,2019.0
-direct firing solid fuels CC,efficiency,1.0,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","312.b Direct firing Sold Fuels:  Total efficiency, net, annual average",2019.0
-direct firing solid fuels CC,investment,221.54,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Nominal investment,2019.0
-direct firing solid fuels CC,lifetime,15.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Technical lifetime,2019.0
-direct iron reduction furnace,FOM,11.3,%/year,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.","55.28 EUR/t_HBI output/a. MPP steel tool uses CAPEX/OPEX for technology ‘DRI-EAF_100% green H2’, substract ‘EAF’ OPEX here to estimate DRI furnace cost.",2020.0
-direct iron reduction furnace,electricity-input,1.03,MWh_el/t_hbi,"Mission Possible Partnership (2022): Steel Model (https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/Technology%20Business%20Cases.csv, accessed: 2022-12-03).",Based on process ‘DRI-EAF_100% green H2’ reduced by electricity demand of process ‘EAF’.,2020.0
-direct iron reduction furnace,hydrogen-input,2.1,MWh_H2/t_hbi,"Mission Possible Partnership (2022): Steel Model Documentation (https://mpp.gitbook.io/mpp-steel-model/model-overview/model-components/technologies, accessed: 2022-12-05). ","63 kg H2/t steel for process ‘DRI-EAF_100% green H2’ according to documentation (raw input files for MPP model list 73 kg H2 / t steel, which seems to high and is probably incorrect).",2020.0
-direct iron reduction furnace,investment,4277858.0,EUR/t_HBI/h,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.","488.34 EUR/t_HBI output/a. MPP steel tool uses CAPEX/OPEX for technology ‘DRI-EAF_100% green H2’, substract ‘EAF’ CAPEX here to estimate DRI furnace cost.",2020.0
-direct iron reduction furnace,lifetime,40.0,years,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.",MPP steel model distinguishes between plant lifetime (40 years) and investment cycle (20 years). Choose plant lifetime.,2020.0
-direct iron reduction furnace,ore-input,1.59,t_ore/t_hbi,"Mission Possible Partnership (2022): Steel Model (https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/Technology%20Business%20Cases.csv, accessed: 2022-12-03). ",Based on process ‘DRI-EAF_100% green H2’.,2020.0
-dry bulk carrier Capesize,FOM,4.0,%/year,"Based on https://www.hellenicshippingnews.com/capesize-freight-returns-below-operating-expense-levels-but-shipowners-reject-lay-ups/, accessed: 2022-12-03.","5000 USD/d OPEX, exchange rate: 1.15 USD = 1 EUR; absolute value calculate relative to investment cost.",2020.0
-dry bulk carrier Capesize,capacity,180000.0,t,-,"DWT; corresponds to size of Capesize bulk carriers which have previously docked at the habour in Hamburg, Germany. Short of 200 kt limit for VLBCs.",2020.0
-dry bulk carrier Capesize,investment,40000000.0,EUR,"Based on https://www.hellenicshippingnews.com/dry-bulk-carriers-in-high-demand-as-rates-keep-rallying/, accessed: 2022-12-03.","See figure for ‘Dry Bulk Newbuild Prices’, Capesize at end of 2020. Exchange rate: 1.15 USD = 1 EUR.",2020.0
-dry bulk carrier Capesize,lifetime,25.0,years,"Based on https://mfame.guru/fall-life-expectancy-bulk-carriers/, accessed: 2022-12-03.",Expected lifetime.,2020.0
-electric arc furnace,FOM,30.0,%/year,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.","EAF has high OPEX of 62.99 EUR/year/t_steel, presumably because of electrode corrosion.",2020.0
-electric arc furnace,electricity-input,0.6395,MWh_el/t_steel,"Mission Possible Partnership (2022): Steel Model (https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/Technology%20Business%20Cases.csv, accessed: 2022-12-03).",Based on process ‘EAF’. ,2020.0
-electric arc furnace,hbi-input,1.0,t_hbi/t_steel,-,Assume HBI instead of scrap as input.Scrap would require higher input (in tonnes) as steel content is lower.,2020.0
-electric arc furnace,investment,1839600.0,EUR/t_steel/h,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.",210 EUR/t_steel output/a. MPP steel tool uses CAPEX/OPEX for technology ‘EAF’.,2020.0
-electric arc furnace,lifetime,40.0,years,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.",MPP steel model distinguishes between plant lifetime (40 years) and investment cycle (20 years). Choose plant lifetime.,2020.0
-electric boiler steam,FOM,1.4571,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Fixed O&M,2019.0
-electric boiler steam,VOM,0.8811,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Variable O&M,2019.0
-electric boiler steam,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","310.1 Electric boiler steam  :  Total efficiency, net, annual average",2019.0
-electric boiler steam,investment,70.49,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Nominal investment,2019.0
-electric boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Technical lifetime,2019.0
-electric steam cracker,FOM,3.0,%/year,Guesstimate,,
-electric steam cracker,VOM,190.4799,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",,2015.0
+digestible biomass to hydrogen,investment,3707.4795,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014
+direct air capture,FOM,4.95,%/year,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020
+direct air capture,compression-electricity-input,0.15,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020
+direct air capture,compression-heat-output,0.2,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020
+direct air capture,electricity-input,0.4,MWh_el/t_CO2,"Beuttler et al (2019): The Role of Direct Air Capture in Mitigation of Antropogenic Greenhouse Gas emissions (https://doi.org/10.3389/fclim.2019.00010), alternative:  Breyer et al (2019).","0.4 MWh based on Beuttler et al (2019) for Climeworks LT DAC, alternative value: 0.182 MWh based on Breyer et al (2019). Should already include electricity for water scrubbing and compression (high quality CO2 output).",2020
+direct air capture,heat-input,1.6,MWh_th/t_CO2,"Beuttler et al (2019): The Role of Direct Air Capture in Mitigation of Antropogenic Greenhouse Gas emissions (https://doi.org/10.3389/fclim.2019.00010), alternative:  Breyer et al (2019).","Thermal energy demand. Provided via air-sourced heat pumps. 1.6 MWh based on Beuttler et al (2019) for Climeworks LT DAC, alternative value: 1.102 MWh based on Breyer et al (2019).",2020
+direct air capture,heat-output,1,MWh/tCO2,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020
+direct air capture,investment,6000000,EUR/(tCO2/h),"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020
+direct air capture,lifetime,20,years,"Danish Energy Agency, technology_data_for_carbon_capture_transport_storage.xlsx",403.a Direct air capture,2020
+direct firing gas,FOM,1.1818,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Fixed O&M,2019
+direct firing gas,VOM,0.2794,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Variable O&M,2019
+direct firing gas,efficiency,1,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","312.a Direct firing Natural Gas:  Total efficiency, net, annual average",2019
+direct firing gas,investment,15.105,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Nominal investment,2019
+direct firing gas,lifetime,15,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Technical lifetime,2019
+direct firing gas CC,FOM,1.1818,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Fixed O&M,2019
+direct firing gas CC,VOM,0.2794,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Variable O&M,2019
+direct firing gas CC,efficiency,1,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","312.a Direct firing Natural Gas:  Total efficiency, net, annual average",2019
+direct firing gas CC,investment,15.105,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Nominal investment,2019
+direct firing gas CC,lifetime,15,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.a Direct firing Natural Gas:  Technical lifetime,2019
+direct firing solid fuels,FOM,1.5,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Fixed O&M,2019
+direct firing solid fuels,VOM,0.3326,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Variable O&M,2019
+direct firing solid fuels,efficiency,1,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","312.b Direct firing Sold Fuels:  Total efficiency, net, annual average",2019
+direct firing solid fuels,investment,221.54,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Nominal investment,2019
+direct firing solid fuels,lifetime,15,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Technical lifetime,2019
+direct firing solid fuels CC,FOM,1.5,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Fixed O&M,2019
+direct firing solid fuels CC,VOM,0.3326,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Variable O&M,2019
+direct firing solid fuels CC,efficiency,1,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","312.b Direct firing Sold Fuels:  Total efficiency, net, annual average",2019
+direct firing solid fuels CC,investment,221.54,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Nominal investment,2019
+direct firing solid fuels CC,lifetime,15,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",312.b Direct firing Sold Fuels:  Technical lifetime,2019
+direct iron reduction furnace,FOM,11.3,%/year,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.","55.28 EUR/t_HBI output/a. MPP steel tool uses CAPEX/OPEX for technology ‘DRI-EAF_100% green H2’, substract ‘EAF’ OPEX here to estimate DRI furnace cost.",2020
+direct iron reduction furnace,electricity-input,1.03,MWh_el/t_hbi,"Mission Possible Partnership (2022): Steel Model (https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/Technology%20Business%20Cases.csv, accessed: 2022-12-03).",Based on process ‘DRI-EAF_100% green H2’ reduced by electricity demand of process ‘EAF’.,2020
+direct iron reduction furnace,hydrogen-input,2.1,MWh_H2/t_hbi,"Mission Possible Partnership (2022): Steel Model Documentation (https://mpp.gitbook.io/mpp-steel-model/model-overview/model-components/technologies, accessed: 2022-12-05). ","63 kg H2/t steel for process ‘DRI-EAF_100% green H2’ according to documentation (raw input files for MPP model list 73 kg H2 / t steel, which seems to high and is probably incorrect).",2020
+direct iron reduction furnace,investment,4277858,EUR/t_HBI/h,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.","488.34 EUR/t_HBI output/a. MPP steel tool uses CAPEX/OPEX for technology ‘DRI-EAF_100% green H2’, substract ‘EAF’ CAPEX here to estimate DRI furnace cost.",2020
+direct iron reduction furnace,lifetime,40,years,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.",MPP steel model distinguishes between plant lifetime (40 years) and investment cycle (20 years). Choose plant lifetime.,2020
+direct iron reduction furnace,ore-input,1.59,t_ore/t_hbi,"Mission Possible Partnership (2022): Steel Model (https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/Technology%20Business%20Cases.csv, accessed: 2022-12-03). ",Based on process ‘DRI-EAF_100% green H2’.,2020
+dry bulk carrier Capesize,FOM,4,%/year,"Based on https://www.hellenicshippingnews.com/capesize-freight-returns-below-operating-expense-levels-but-shipowners-reject-lay-ups/, accessed: 2022-12-03.","5000 USD/d OPEX, exchange rate: 1.15 USD = 1 EUR; absolute value calculate relative to investment cost.",2020
+dry bulk carrier Capesize,capacity,180000,t,-,"DWT; corresponds to size of Capesize bulk carriers which have previously docked at the habour in Hamburg, Germany. Short of 200 kt limit for VLBCs.",2020
+dry bulk carrier Capesize,investment,40000000,EUR,"Based on https://www.hellenicshippingnews.com/dry-bulk-carriers-in-high-demand-as-rates-keep-rallying/, accessed: 2022-12-03.","See figure for ‘Dry Bulk Newbuild Prices’, Capesize at end of 2020. Exchange rate: 1.15 USD = 1 EUR.",2020
+dry bulk carrier Capesize,lifetime,25,years,"Based on https://mfame.guru/fall-life-expectancy-bulk-carriers/, accessed: 2022-12-03.",Expected lifetime.,2020
+electric arc furnace,FOM,30,%/year,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.","EAF has high OPEX of 62.99 EUR/year/t_steel, presumably because of electrode corrosion.",2020
+electric arc furnace,electricity-input,0.6395,MWh_el/t_steel,"Mission Possible Partnership (2022): Steel Model (https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/Technology%20Business%20Cases.csv, accessed: 2022-12-03).",Based on process ‘EAF’. ,2020
+electric arc furnace,hbi-input,1,t_hbi/t_steel,-,Assume HBI instead of scrap as input.Scrap would require higher input (in tonnes) as steel content is lower.,2020
+electric arc furnace,investment,1839600,EUR/t_steel/h,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.",210 EUR/t_steel output/a. MPP steel tool uses CAPEX/OPEX for technology ‘EAF’.,2020
+electric arc furnace,lifetime,40,years,"Model assumptions from MPP Steel Transition Tool: https://github.com/missionpossiblepartnership/mpp-steel-model/blob/9eca52db92bd2d9715f30e98ccaaf36677fdb516/mppsteel/data/import_data/CAPEX%20OPEX%20Per%20Technology.xlsx, accessed: 2022-12-05.",MPP steel model distinguishes between plant lifetime (40 years) and investment cycle (20 years). Choose plant lifetime.,2020
+electric boiler steam,FOM,1.4571,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Fixed O&M,2019
+electric boiler steam,VOM,0.8811,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Variable O&M,2019
+electric boiler steam,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","310.1 Electric boiler steam  :  Total efficiency, net, annual average",2019
+electric boiler steam,investment,70.49,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Nominal investment,2019
+electric boiler steam,lifetime,25,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Technical lifetime,2019
+electric steam cracker,FOM,3,%/year,Guesstimate,,2015
+electric steam cracker,VOM,190.4799,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",,2015
 electric steam cracker,carbondioxide-output,0.55,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), ",The report also references another source with 0.76 t_CO2/t_HVC,
 electric steam cracker,electricity-input,2.7,MWh_el/t_HVC,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",Assuming electrified processing.,
-electric steam cracker,investment,11124025.7434,EUR/(t_HVC/h),"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",Assuming CAPEX of 1200 €/t actually given in €/(t/a).,2015.0
-electric steam cracker,lifetime,30.0,years,Guesstimate,,
+electric steam cracker,investment,11124025.7434,EUR/(t_HVC/h),"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",Assuming CAPEX of 1200 €/t actually given in €/(t/a).,2015
+electric steam cracker,lifetime,30,years,Guesstimate,,
 electric steam cracker,naphtha-input,14.8,MWh_naphtha/t_HVC,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",,
-electricity distribution grid,FOM,2.0,%/year,TODO, from old pypsa cost assumptions,2015.0
-electricity distribution grid,investment,529.1108,EUR/kW,TODO, from old pypsa cost assumptions,2015.0
-electricity distribution grid,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
-electricity grid connection,FOM,2.0,%/year,TODO, from old pypsa cost assumptions,2015.0
-electricity grid connection,investment,148.151,EUR/kW,DEA, from old pypsa cost assumptions,2015.0
-electricity grid connection,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
+electricity distribution grid,FOM,2,%/year,TODO, from old pypsa cost assumptions,2015
+electricity distribution grid,investment,529.1108,EUR/kW,TODO, from old pypsa cost assumptions,2015
+electricity distribution grid,lifetime,40,years,TODO, from old pypsa cost assumptions,2015
+electricity grid connection,FOM,2,%/year,TODO, from old pypsa cost assumptions,2015
+electricity grid connection,investment,148.151,EUR/kW,DEA, from old pypsa cost assumptions,2015
+electricity grid connection,lifetime,40,years,TODO, from old pypsa cost assumptions,2015
 electrobiofuels,C in fuel,0.9269,per unit,Stoichiometric calculation,,
-electrobiofuels,FOM,2.6667,%/year,combination of BtL and electrofuels,,
-electrobiofuels,VOM,4.2296,EUR/MWh_th,combination of BtL and electrofuels,,2017.0
+electrobiofuels,FOM,2.6667,%/year,combination of BtL and electrofuels,,2015
+electrobiofuels,VOM,4.2296,EUR/MWh_th,combination of BtL and electrofuels,,2017
 electrobiofuels,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 electrobiofuels,efficiency-biomass,1.3217,per unit,Stoichiometric calculation,,
 electrobiofuels,efficiency-hydrogen,1.2142,per unit,Stoichiometric calculation,,
 electrobiofuels,efficiency-tot,0.6328,per unit,Stoichiometric calculation,,
-electrobiofuels,investment,466206.9921,EUR/kW_th,combination of BtL and electrofuels,,2017.0
-electrolysis,FOM,4.0,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 100 MW:  Fixed O&M ,2020.0
-electrolysis,efficiency,0.6217,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 100 MW:  Hydrogen Output,2020.0
-electrolysis,efficiency-heat,0.2228,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 100 MW:   - hereof recoverable for district heating,2020.0
-electrolysis,investment,1500.0,EUR/kW_e,private communications; IEA https://iea.blob.core.windows.net/assets/9e0c82d4-06d2-496b-9542-f184ba803645/TheRoleofE-fuelsinDecarbonisingTransport.pdf,,2020.0
-electrolysis,lifetime,25.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 100 MW:  Technical lifetime,2020.0
-electrolysis small,FOM,4.0,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:  Fixed O&M ,2020.0
-electrolysis small,efficiency,0.6217,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:  Hydrogen Output,2020.0
-electrolysis small,efficiency-heat,0.2228,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:   - hereof recoverable for district heating,2020.0
-electrolysis small,investment,875.0,EUR/kW_e,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:  Specific investment,2020.0
-electrolysis small,lifetime,25.0,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:  Technical lifetime of plant,2020.0
-fuel cell,FOM,5.0,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Fixed O&M,2015.0
-fuel cell,c_b,1.25,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Cb coefficient,2015.0
-fuel cell,efficiency,0.5,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","12 LT-PEMFC CHP:  Electricity efficiency, annual average",2015.0
-fuel cell,investment,1164.0438,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Nominal investment,2015.0
-fuel cell,lifetime,10.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Technical lifetime,2015.0
-fuelwood,fuel,14.5224,EUR/MWhth,"JRC ENSPRESO ca avg for MINBIOWOO (FuelwoodRW), ENS_BaU_GFTM",,2010.0
+electrobiofuels,investment,466206.9921,EUR/kW_th,combination of BtL and electrofuels,,2017
+electrolysis,FOM,4,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 100 MW:  Fixed O&M ,2020
+electrolysis,efficiency,0.6217,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 100 MW:  Hydrogen Output,2020
+electrolysis,efficiency-heat,0.2228,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 100 MW:   - hereof recoverable for district heating,2020
+electrolysis,investment,1500,EUR/kW_e,private communications; IEA https://iea.blob.core.windows.net/assets/9e0c82d4-06d2-496b-9542-f184ba803645/TheRoleofE-fuelsinDecarbonisingTransport.pdf,,2020
+electrolysis,lifetime,25,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 100 MW:  Technical lifetime,2020
+electrolysis small,FOM,4,%/year,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:  Fixed O&M ,2020
+electrolysis small,efficiency,0.6217,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:  Hydrogen Output,2020
+electrolysis small,efficiency-heat,0.2228,per unit,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:   - hereof recoverable for district heating,2020
+electrolysis small,investment,875,EUR/kW_e,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:  Specific investment,2020
+electrolysis small,lifetime,25,years,"Danish Energy Agency, data_sheets_for_renewable_fuels.xlsx",86 AEC 10 MW:  Technical lifetime of plant,2020
+fuel cell,FOM,5,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Fixed O&M,2015
+fuel cell,c_b,1.25,50oC/100oC,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Cb coefficient,2015
+fuel cell,efficiency,0.5,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","12 LT-PEMFC CHP:  Electricity efficiency, annual average",2015
+fuel cell,investment,1164.0438,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Nominal investment,2015
+fuel cell,lifetime,10,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",12 LT-PEMFC CHP:  Technical lifetime,2015
+fuelwood,fuel,14.5224,EUR/MWhth,"JRC ENSPRESO ca avg for MINBIOWOO (FuelwoodRW), ENS_BaU_GFTM",,2010
 gas,CO2 intensity,0.198,tCO2/MWh_th,Stoichiometric calculation with 50 GJ/t CH4,,
-gas,fuel,24.568,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.",Based on IEA 2011 data.,2010.0
-gas boiler steam,FOM,4.18,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1c Steam boiler Gas:  Fixed O&M,2019.0
-gas boiler steam,VOM,1.007,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1c Steam boiler Gas:  Variable O&M,2019.0
-gas boiler steam,efficiency,0.93,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1c Steam boiler Gas:  Total efficiency, net, annual average",2019.0
-gas boiler steam,investment,45.7727,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1c Steam boiler Gas:  Nominal investment,2019.0
-gas boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1c Steam boiler Gas:  Technical lifetime,2019.0
-gas storage,FOM,3.5919,%,Danish Energy Agency,"150 Underground Storage of Gas, Operation and Maintenace, salt cavern (units converted)",2015.0
-gas storage,investment,0.0348,EUR/kWh,Danish Energy Agency,"150 Underground Storage of Gas, Establishment of one cavern (units converted)",2015.0
-gas storage,lifetime,100.0,years,TODO no source,"estimation: most underground storage are already build, they do have a long lifetime",2015.0
-gas storage charger,investment,15.1737,EUR/kW,Danish Energy Agency,"150 Underground Storage of Gas, Process equipment (units converted)",2015.0
-gas storage discharger,investment,5.0579,EUR/kW,Danish Energy Agency,"150 Underground Storage of Gas, Process equipment (units converted)",2015.0
-geothermal,CO2 intensity,0.12,tCO2/MWh_th,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551",Likely to be improved; Average of 85 percent of global egs power plant capacity; Result of fluid circulation through rock formations,2020.0
-geothermal,FOM,2.0,%/year,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551",See Supplemental Material of source for details,2020.0
-geothermal,district heat surcharge,25.0,%,Frey et al. 2022: Techno-Economic Assessment of Geothermal Resources in the Variscan Basement of the Northern Upper Rhine Graben,"If capital cost of electric generation from EGS is 100%, district heating adds additional 25%. Costs incurred by piping.",2020.0
-geothermal,district heat-input,0.8,MWh_thdh/MWh_th,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551; Breede et al. 2015: Overcoming challenges in the classification of deep geothermal potential, https://eprints.gla.ac.uk/169585/","Heat-input, District Heat-output. This is an assessment of typical heat losses when heat is transmitted from the EGS plant to the DH network, This is a rough estimate, depends on local conditions",2020.0
-geothermal,lifetime,30.0,years,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551",,2020.0
-helmeth,FOM,3.0,%/year,no source, from old pypsa cost assumptions,2015.0
-helmeth,efficiency,0.8,per unit,HELMETH press release, from old pypsa cost assumptions,2015.0
-helmeth,investment,2116.4433,EUR/kW,no source, from old pypsa cost assumptions,2015.0
-helmeth,lifetime,25.0,years,no source, from old pypsa cost assumptions,2015.0
-home battery inverter,FOM,0.3375,%/year,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Fixed O&M,2015.0
-home battery inverter,efficiency,0.96,per unit,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Round trip efficiency DC,2015.0
-home battery inverter,investment,241.3377,EUR/kW,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Output capacity expansion cost investment,2015.0
-home battery inverter,lifetime,10.0,years,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx, Note K.",:  Technical lifetime,2015.0
-home battery storage,investment,214.7158,EUR/kWh,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Energy storage expansion cost investment,2015.0
-home battery storage,lifetime,25.0,years,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Technical lifetime,2015.0
-hydro,FOM,1.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-hydro,investment,2274.8177,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
-hydro,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
-hydrogen storage compressor,FOM,4.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-,2020.0
-hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",1.707 kWh/kg.,2020.0
-hydrogen storage compressor,investment,87.69,EUR/kW_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.","2923 EUR/kg_H2. For a 206 kg/h compressor. Base CAPEX 40 528 EUR/kW_el with scale factor 0.4603. kg_H2 converted to MWh using LHV. Pressure range: 30 bar in, 250 bar out.",2020.0
-hydrogen storage compressor,lifetime,15.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-,2020.0
-hydrogen storage tank type 1,FOM,2.0,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-,2020.0
-hydrogen storage tank type 1,investment,13.5,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.","450 EUR/kg_H2 converted with LHV to MWh. For a type 1 hydrogen storage tank (steel, 15-250 bar). Currency year assumed 2020 for initial publication of reference; observe note in SI.4.3 that no currency year is explicitly stated in the reference.",2020.0
-hydrogen storage tank type 1,lifetime,20.0,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-,2020.0
-hydrogen storage tank type 1,min_fill_level,6.0,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-,2020.0
-hydrogen storage tank type 1 including compressor,FOM,1.1133,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M,2015.0
-hydrogen storage tank type 1 including compressor,investment,47.5247,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment,2015.0
-hydrogen storage tank type 1 including compressor,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime,2015.0
-hydrogen storage underground,FOM,0.0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M,2015.0
-hydrogen storage underground,VOM,0.0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M,2015.0
-hydrogen storage underground,investment,2.1164,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment,2015.0
-hydrogen storage underground,lifetime,100.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Technical lifetime,2015.0
-industrial heat pump high temperature,FOM,0.0931,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.b High temp. hp Up to 150:  Fixed O&M,2019.0
-industrial heat pump high temperature,VOM,3.2224,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.b High temp. hp Up to 150:  Variable O&M,2019.0
-industrial heat pump high temperature,efficiency,3.05,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","302.b High temp. hp Up to 150:  Total efficiency, net, annual average",2019.0
-industrial heat pump high temperature,investment,941.1019,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.b High temp. hp Up to 150:  Nominal investment,2019.0
-industrial heat pump high temperature,lifetime,20.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.b High temp. hp Up to 150:  Technical lifetime,2019.0
-industrial heat pump medium temperature,FOM,0.1117,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.a High temp. hp Up to 125 C:  Fixed O&M,2019.0
-industrial heat pump medium temperature,VOM,3.2224,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.a High temp. hp Up to 125 C:  Variable O&M,2019.0
-industrial heat pump medium temperature,efficiency,2.7,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","302.a High temp. hp Up to 125 C:  Total efficiency, net, annual average",2019.0
-industrial heat pump medium temperature,investment,784.2516,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.a High temp. hp Up to 125 C:  Nominal investment,2019.0
-industrial heat pump medium temperature,lifetime,20.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.a High temp. hp Up to 125 C:  Technical lifetime,2019.0
-iron ore DRI-ready,commodity,97.73,EUR/t,"Model assumptions from MPP Steel Transition Tool: https://missionpossiblepartnership.org/action-sectors/steel/, accessed: 2022-12-03.","DRI ready assumes 65% iron content, requiring no additional benefication.",2020.0
-iron-air battery,FOM,1.0,%/year,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020.0
-iron-air battery,investment,15.61,EUR/kWh,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020.0
-iron-air battery,lifetime,17.5,years,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020.0
-iron-air battery charge,efficiency,0.71,per unit,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020.0
-iron-air battery discharge,efficiency,0.6,per unit,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020.0
+gas,fuel,24.568,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.",Based on IEA 2011 data.,2010
+gas boiler steam,FOM,4.18,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1c Steam boiler Gas:  Fixed O&M,2019
+gas boiler steam,VOM,1.007,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1c Steam boiler Gas:  Variable O&M,2019
+gas boiler steam,efficiency,0.93,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1c Steam boiler Gas:  Total efficiency, net, annual average",2019
+gas boiler steam,investment,45.7727,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1c Steam boiler Gas:  Nominal investment,2019
+gas boiler steam,lifetime,25,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1c Steam boiler Gas:  Technical lifetime,2019
+gas storage,FOM,3.5919,%,Danish Energy Agency,"150 Underground Storage of Gas, Operation and Maintenace, salt cavern (units converted)",2015
+gas storage,investment,0.0348,EUR/kWh,Danish Energy Agency,"150 Underground Storage of Gas, Establishment of one cavern (units converted)",2015
+gas storage,lifetime,100,years,TODO no source,"estimation: most underground storage are already build, they do have a long lifetime",2015
+gas storage charger,investment,15.1737,EUR/kW,Danish Energy Agency,"150 Underground Storage of Gas, Process equipment (units converted)",2015
+gas storage discharger,investment,5.0579,EUR/kW,Danish Energy Agency,"150 Underground Storage of Gas, Process equipment (units converted)",2015
+geothermal,CO2 intensity,0.12,tCO2/MWh_th,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551",Likely to be improved; Average of 85 percent of global egs power plant capacity; Result of fluid circulation through rock formations,2020
+geothermal,FOM,2,%/year,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551",See Supplemental Material of source for details,2020
+geothermal,district heat surcharge,25,%,Frey et al. 2022: Techno-Economic Assessment of Geothermal Resources in the Variscan Basement of the Northern Upper Rhine Graben,"If capital cost of electric generation from EGS is 100%, district heating adds additional 25%. Costs incurred by piping.",2020
+geothermal,district heat-input,0.8,MWh_thdh/MWh_th,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551; Breede et al. 2015: Overcoming challenges in the classification of deep geothermal potential, https://eprints.gla.ac.uk/169585/","Heat-input, District Heat-output. This is an assessment of typical heat losses when heat is transmitted from the EGS plant to the DH network, This is a rough estimate, depends on local conditions",2020
+geothermal,lifetime,30,years,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551",,2020
+helmeth,FOM,3,%/year,no source, from old pypsa cost assumptions,2015
+helmeth,efficiency,0.8,per unit,HELMETH press release, from old pypsa cost assumptions,2015
+helmeth,investment,2116.4433,EUR/kW,no source, from old pypsa cost assumptions,2015
+helmeth,lifetime,25,years,no source, from old pypsa cost assumptions,2015
+home battery inverter,FOM,0.3375,%/year,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Fixed O&M,2015
+home battery inverter,efficiency,0.96,per unit,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Round trip efficiency DC,2015
+home battery inverter,investment,241.3377,EUR/kW,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Output capacity expansion cost investment,2015
+home battery inverter,lifetime,10,years,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx, Note K.",:  Technical lifetime,2015
+home battery storage,investment,214.7158,EUR/kWh,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Energy storage expansion cost investment,2015
+home battery storage,lifetime,25,years,"Global Energy System based on 100% Renewable Energy, Energywatchgroup/LTU University, 2019, Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",:  Technical lifetime,2015
+hydro,FOM,1,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+hydro,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+hydro,investment,2274.8177,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010
+hydro,lifetime,80,years,IEA2010, from old pypsa cost assumptions,2015
+hydrogen storage compressor,FOM,4,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-,2020
+hydrogen storage compressor,compression-electricity-input,0.05,MWh_el/MWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",1.707 kWh/kg.,2020
+hydrogen storage compressor,investment,87.69,EUR/kW_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.","2923 EUR/kg_H2. For a 206 kg/h compressor. Base CAPEX 40 528 EUR/kW_el with scale factor 0.4603. kg_H2 converted to MWh using LHV. Pressure range: 30 bar in, 250 bar out.",2020
+hydrogen storage compressor,lifetime,15,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.4.",-,2020
+hydrogen storage tank type 1,FOM,2,%/year,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-,2020
+hydrogen storage tank type 1,investment,13.5,EUR/kWh_H2,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.","450 EUR/kg_H2 converted with LHV to MWh. For a type 1 hydrogen storage tank (steel, 15-250 bar). Currency year assumed 2020 for initial publication of reference; observe note in SI.4.3 that no currency year is explicitly stated in the reference.",2020
+hydrogen storage tank type 1,lifetime,20,years,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-,2020
+hydrogen storage tank type 1,min_fill_level,6,%,"Based on Stöckl et al (2021): https://doi.org/10.48550/arXiv.2005.03464, table SI.9.",-,2020
+hydrogen storage tank type 1 including compressor,FOM,1.1133,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Fixed O&M,2015
+hydrogen storage tank type 1 including compressor,investment,47.5247,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Specific investment,2015
+hydrogen storage tank type 1 including compressor,lifetime,30,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151a Hydrogen Storage - Tanks:  Technical lifetime,2015
+hydrogen storage underground,FOM,0,%/year,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Fixed O&M,2015
+hydrogen storage underground,VOM,0,EUR/MWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Variable O&M,2015
+hydrogen storage underground,investment,2.1164,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Specific investment,2015
+hydrogen storage underground,lifetime,100,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",151c Hydrogen Storage - Caverns:  Technical lifetime,2015
+industrial heat pump high temperature,FOM,0.0931,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.b High temp. hp Up to 150:  Fixed O&M,2019
+industrial heat pump high temperature,VOM,3.2224,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.b High temp. hp Up to 150:  Variable O&M,2019
+industrial heat pump high temperature,efficiency,3.05,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","302.b High temp. hp Up to 150:  Total efficiency, net, annual average",2019
+industrial heat pump high temperature,investment,941.1019,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.b High temp. hp Up to 150:  Nominal investment,2019
+industrial heat pump high temperature,lifetime,20,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.b High temp. hp Up to 150:  Technical lifetime,2019
+industrial heat pump medium temperature,FOM,0.1117,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.a High temp. hp Up to 125 C:  Fixed O&M,2019
+industrial heat pump medium temperature,VOM,3.2224,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.a High temp. hp Up to 125 C:  Variable O&M,2019
+industrial heat pump medium temperature,efficiency,2.7,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","302.a High temp. hp Up to 125 C:  Total efficiency, net, annual average",2019
+industrial heat pump medium temperature,investment,784.2516,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.a High temp. hp Up to 125 C:  Nominal investment,2019
+industrial heat pump medium temperature,lifetime,20,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",302.a High temp. hp Up to 125 C:  Technical lifetime,2019
+iron ore DRI-ready,commodity,97.73,EUR/t,"Model assumptions from MPP Steel Transition Tool: https://missionpossiblepartnership.org/action-sectors/steel/, accessed: 2022-12-03.","DRI ready assumes 65% iron content, requiring no additional benefication.",2020
+iron-air battery,FOM,1,%/year,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020
+iron-air battery,investment,15.61,EUR/kWh,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020
+iron-air battery,lifetime,17.5,years,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020
+iron-air battery charge,efficiency,0.71,per unit,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020
+iron-air battery discharge,efficiency,0.6,per unit,"Form Energy, FormEnergy_Europe_modeling_recommendations_2023.03.pdf, p4",,2020
 lignite,CO2 intensity,0.4069,tCO2/MWh_th,Entwicklung der spezifischen Kohlendioxid-Emissionen des deutschen Strommix in den Jahren 1990 - 2018,,
-lignite,FOM,1.31,%/year,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. (39.5+91.25) USD/kW_e/a /2 / (1.09 USD/EUR) / investment cost * 100. Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf . ",2023.0
-lignite,VOM,3.2612,EUR/MWh_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. (3+5.5)USD/MWh_e/2 / (1.09 USD/EUR). Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf . ",2023.0
-lignite,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. 1 / ((8.75+12) MMbtu/MWh_th /2 / (3.4095 MMbtu/MWh_th)), rounded up. Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf . ",2023.0
-lignite,fuel,3.2985,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 10 USD/t.",2010.0
-lignite,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR). Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf .",2023.0
-lignite,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf . ",2023.0
-methanation,FOM,3.0,%/year,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), section 6.2.3.1",,2017.0
+lignite,FOM,1.31,%/year,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. (39.5+91.25) USD/kW_e/a /2 / (1.09 USD/EUR) / investment cost * 100. Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf . ",2023
+lignite,VOM,3.2612,EUR/MWh_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. (3+5.5)USD/MWh_e/2 / (1.09 USD/EUR). Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf . ",2023
+lignite,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Calculated based on average of listed range, i.e. 1 / ((8.75+12) MMbtu/MWh_th /2 / (3.4095 MMbtu/MWh_th)), rounded up. Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf . ",2023
+lignite,fuel,3.2985,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 10 USD/t.",2010
+lignite,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR). Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf .",2023
+lignite,lifetime,40,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Note: Assume same costs as for hard coal, as cost structure is apparently comparable, see https://diglib.tugraz.at/download.php?id=6093e88b63f93&location=browse and https://iea.blob.core.windows.net/assets/ae17da3d-e8a5-4163-a3ec-2e6fb0b5677d/Projected-Costs-of-Generating-Electricity-2020.pdf . ",2023
+methanation,FOM,3,%/year,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), section 6.2.3.1",,2017
 methanation,carbondioxide-input,0.198,t_CO2/MWh_CH4,"Götz et al. (2016): Renewable Power-to-Gas: A technological and economic review (https://doi.org/10.1016/j.renene.2015.07.066), Fig. 11 .",Additional H2 required for methanation process (2x H2 amount compared to stochiometric conversion).,
-methanation,efficiency,0.8,per unit,Palzer and Schaber thesis, from old pypsa cost assumptions,2015.0
+methanation,efficiency,0.8,per unit,Palzer and Schaber thesis, from old pypsa cost assumptions,2015
 methanation,hydrogen-input,1.282,MWh_H2/MWh_CH4,,Based on ideal conversion process of stochiometric composition (1 t CH4 contains 750 kg of carbon).,
-methanation,investment,679.8185,EUR/kW_CH4,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), table 6: “Reference scenario”.",,2017.0
-methanation,lifetime,20.0,years,Guesstimate.,"Based on lifetime for methanolisation, Fischer-Tropsch plants.",2017.0
-methane storage tank incl. compressor,FOM,1.9,%/year,"Guesstimate, based on hydrogen storage tank type 1 including compressor by DEA.",Based on assumptions for hydrogen storage tank type 1 including compressor (by DEA).,2014.0
-methane storage tank incl. compressor,investment,8961.5075,EUR/m^3,Storage costs per l: https://www.compositesworld.com/articles/pressure-vessels-for-alternative-fuels-2014-2023 (2021-02-10).,"Assume 5USD/l (= 4.23 EUR/l at 1.17 USD/EUR exchange rate) for type 1 pressure vessel for 200 bar storage and 100% surplus costs for including compressor costs with storage, based on similar assumptions by DEA for compressed hydrogen storage tanks.",2014.0
-methane storage tank incl. compressor,lifetime,30.0,years,"Guesstimate, based on hydrogen storage tank type 1 including compressor by DEA.",Based on assumptions for hydrogen storage tank 1 including compressor (by DEA).,2014.0
+methanation,investment,679.8185,EUR/kW_CH4,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), table 6: “Reference scenario”.",,2017
+methanation,lifetime,20,years,Guesstimate.,"Based on lifetime for methanolisation, Fischer-Tropsch plants.",2017
+methane storage tank incl. compressor,FOM,1.9,%/year,"Guesstimate, based on hydrogen storage tank type 1 including compressor by DEA.",Based on assumptions for hydrogen storage tank type 1 including compressor (by DEA).,2014
+methane storage tank incl. compressor,investment,8961.5075,EUR/m^3,Storage costs per l: https://www.compositesworld.com/articles/pressure-vessels-for-alternative-fuels-2014-2023 (2021-02-10).,"Assume 5USD/l (= 4.23 EUR/l at 1.17 USD/EUR exchange rate) for type 1 pressure vessel for 200 bar storage and 100% surplus costs for including compressor costs with storage, based on similar assumptions by DEA for compressed hydrogen storage tanks.",2014
+methane storage tank incl. compressor,lifetime,30,years,"Guesstimate, based on hydrogen storage tank type 1 including compressor by DEA.",Based on assumptions for hydrogen storage tank 1 including compressor (by DEA).,2014
 methanol,CO2 intensity,0.2482,tCO2/MWh_th,,,
-methanol-to-kerosene,FOM,4.5,%/year,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
-methanol-to-kerosene,VOM,1.35,EUR/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
+methanol-to-kerosene,FOM,4.5,%/year,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020
+methanol-to-kerosene,VOM,1.35,EUR/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020
 methanol-to-kerosene,hydrogen-input,0.0279,MWh_H2/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 6.","Assuming LHV 11.94 kWh/kg for kerosene, 5.54 kWh/kg for methanol, 33.3 kWh/kg for hydrogen.",
-methanol-to-kerosene,investment,269000.0,EUR/MW_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
-methanol-to-kerosene,lifetime,30.0,years,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,
+methanol-to-kerosene,investment,269000,EUR/MW_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020
+methanol-to-kerosene,lifetime,30,years,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,
 methanol-to-kerosene,methanol-input,1.0764,MWh_MeOH/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 6.","Assuming LHV 11.94 kWh/kg for kerosene, 5.54 kWh/kg for methanol, 33.3 kWh/kg for hydrogen.",
-methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,
-methanol-to-olefins/aromatics,VOM,31.7466,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", ,2015.0
+methanol-to-olefins/aromatics,FOM,3,%/year,Guesstimate,same as steam cracker,2015
+methanol-to-olefins/aromatics,VOM,31.7466,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", ,2015
 methanol-to-olefins/aromatics,carbondioxide-output,0.6107,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 0.4 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 1.13 t_CO2/t_BTX for 15.7 Mt of BTX. The report also references process emissions of 0.55 t_MeOH/t_ethylene+propylene elsewhere. ",
 methanol-to-olefins/aromatics,electricity-input,1.3889,MWh_el/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), page 69",5 GJ/t_HVC ,
-methanol-to-olefins/aromatics,investment,2781006.4359,EUR/(t_HVC/h),"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",Assuming CAPEX of 1200 €/t actually given in €/(t/a).,2015.0
-methanol-to-olefins/aromatics,lifetime,30.0,years,Guesstimate,same as steam cracker,
+methanol-to-olefins/aromatics,investment,2781006.4359,EUR/(t_HVC/h),"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",Assuming CAPEX of 1200 €/t actually given in €/(t/a).,2015
+methanol-to-olefins/aromatics,lifetime,30,years,Guesstimate,same as steam cracker,
 methanol-to-olefins/aromatics,methanol-input,18.03,MWh_MeOH/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 2.83 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 4.2 t_MeOH/t_BTX for 15.7 Mt of BTX. Assuming 5.54 MWh_MeOH/t_MeOH. ",
-methanolisation,FOM,3.0,%/year,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), section 6.3.2.1.",,2017.0
+methanolisation,FOM,3,%/year,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), section 6.3.2.1.",,2017
 methanolisation,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 methanolisation,carbondioxide-input,0.248,t_CO2/MWh_MeOH,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf) , pg. 66.",,
 methanolisation,electricity-input,0.271,MWh_e/MWh_MeOH,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf) , pg. 65.",,
 methanolisation,heat-output,0.1,MWh_th/MWh_MeOH,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf) , pg. 65.",steam generation of 2 GJ/t_MeOH,
 methanolisation,hydrogen-input,1.138,MWh_H2/MWh_MeOH,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf) , pg. 64.",189 kg_H2 per t_MeOH,
-methanolisation,investment,703726.4462,EUR/MW_MeOH,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), table 8: “Reference scenario”.","Well developed technology, no significant learning expected.",2017.0
-methanolisation,lifetime,20.0,years,"Danish Energy Agency, Technology Data for Renewable Fuels (04/2022), Data sheet “Methanol to Power”.",,2017.0
-micro CHP,FOM,6.1111,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",219 LT-PEMFC mCHP - natural gas:  Fixed O&M,2015.0
-micro CHP,efficiency,0.351,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","219 LT-PEMFC mCHP - natural gas:  Electric efficiency, annual average, net",2015.0
-micro CHP,efficiency-heat,0.609,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","219 LT-PEMFC mCHP - natural gas:  Heat efficiency, annual average, net",2015.0
-micro CHP,investment,7841.7127,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",219 LT-PEMFC mCHP - natural gas:  Specific investment,2015.0
-micro CHP,lifetime,20.0,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",219 LT-PEMFC mCHP - natural gas:  Technical lifetime,2015.0
-nuclear,FOM,1.27,%/year,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","U.S. specific costs including newly commissioned Vogtle plant, average of range and currency converted, i.e. (131.5+152.75)/2 USD/kW_e / (1.09 USD/EUR) relative to investment costs.",2023.0
-nuclear,VOM,3.5464,EUR/MWh_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","U.S. specific costs including newly commissioned Vogtle plant, average of range and currency converted, i.e. (4.25+5)/2 USD/kW_e / (1.09 USD/EUR) .",2023.0
-nuclear,efficiency,0.326,p.u.,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Based on heat rate of 10.45 MMBtu/MWh_e and 3.4095 MMBtu/MWh_th, i.e. 1/(10.45/3.4095) = 0.3260.",2023.0
-nuclear,fuel,3.4122,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.",Based on IEA 2011 data.,2010.0
-nuclear,investment,8594.1354,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","U.S. specific costs including newly commissioned Vogtle plant, average of range and currency converted, i.e. (8475+13925)/2 USD/kW_e / (1.09 USD/EUR) .",2023.0
-nuclear,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023.0
-offwind,FOM,2.3185,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","21 Offshore turbines:  Fixed O&M [EUR/MW_e/y, 2020]",2020.0
-offwind,VOM,0.0212,EUR/MWhel,RES costs made up to fix curtailment order, from old pypsa cost assumptions,2015.0
-offwind,investment,1682.1226,"EUR/kW_e, 2020","Danish Energy Agency, technology_data_for_el_and_dh.xlsx","21 Offshore turbines:  Nominal investment [MEUR/MW_e, 2020] grid connection costs substracted from investment costs",2020.0
-offwind,lifetime,30.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",21 Offshore turbines:  Technical lifetime [years],2020.0
-offwind-ac-connection-submarine,investment,2841.3251,EUR/MW/km,DEA https://ens.dk/en/our-services/projections-and-models/technology-data, from old pypsa cost assumptions,2015.0
-offwind-ac-connection-underground,investment,1420.1334,EUR/MW/km,DEA https://ens.dk/en/our-services/projections-and-models/technology-data, from old pypsa cost assumptions,2015.0
-offwind-ac-station,investment,264.5554,EUR/kWel,DEA https://ens.dk/en/our-services/projections-and-models/technology-data, from old pypsa cost assumptions,2015.0
-offwind-dc-connection-submarine,investment,2116.4433,EUR/MW/km,DTU report based on Fig 34 of https://ec.europa.eu/energy/sites/ener/files/documents/2014_nsog_report.pdf, from old pypsa cost assumptions,2015.0
-offwind-dc-connection-underground,investment,1058.2216,EUR/MW/km,Haertel 2017; average + 13% learning reduction, from old pypsa cost assumptions,2015.0
-offwind-dc-station,investment,423.2887,EUR/kWel,Haertel 2017; assuming one onshore and one offshore node + 13% learning reduction, from old pypsa cost assumptions,2015.0
-offwind-float,FOM,1.15,%/year,https://doi.org/10.1016/j.adapen.2021.100067,,2020.0
-offwind-float,investment,2350.0,EUR/kWel,https://doi.org/10.1016/j.adapen.2021.100067,,2020.0
-offwind-float,lifetime,20.0,years,C. Maienza 2020 A life cycle cost model for floating offshore wind farms,,2020.0
-offwind-float-connection-submarine,investment,2118.5597,EUR/MW/km,DTU report based on Fig 34 of https://ec.europa.eu/energy/sites/ener/files/documents/2014_nsog_report.pdf,,2014.0
-offwind-float-connection-underground,investment,1039.4778,EUR/MW/km,Haertel 2017, average + 13% learning reduction,2017.0
-offwind-float-station,investment,415.7911,EUR/kWel,Haertel 2017, assuming one onshore and one offshore node + 13% learning reduction,2017.0
+methanolisation,investment,703726.4462,EUR/MW_MeOH,"Agora Energiewende (2018): The Future Cost of Electricity-Based Synthetic Fuels (https://www.agora-energiewende.de/en/publications/the-future-cost-of-electricity-based-synthetic-fuels-1/), table 8: “Reference scenario”.","Well developed technology, no significant learning expected.",2017
+methanolisation,lifetime,20,years,"Danish Energy Agency, Technology Data for Renewable Fuels (04/2022), Data sheet “Methanol to Power”.",,2017
+micro CHP,FOM,6.1111,%/year,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",219 LT-PEMFC mCHP - natural gas:  Fixed O&M,2015
+micro CHP,efficiency,0.351,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","219 LT-PEMFC mCHP - natural gas:  Electric efficiency, annual average, net",2015
+micro CHP,efficiency-heat,0.609,per unit,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx","219 LT-PEMFC mCHP - natural gas:  Heat efficiency, annual average, net",2015
+micro CHP,investment,7841.7127,EUR/kW_th,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",219 LT-PEMFC mCHP - natural gas:  Specific investment,2015
+micro CHP,lifetime,20,years,"Danish Energy Agency, technologydatafor_heating_installations_marts_2018.xlsx",219 LT-PEMFC mCHP - natural gas:  Technical lifetime,2015
+nuclear,FOM,1.27,%/year,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","U.S. specific costs including newly commissioned Vogtle plant, average of range and currency converted, i.e. (131.5+152.75)/2 USD/kW_e / (1.09 USD/EUR) relative to investment costs.",2023
+nuclear,VOM,3.5464,EUR/MWh_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","U.S. specific costs including newly commissioned Vogtle plant, average of range and currency converted, i.e. (4.25+5)/2 USD/kW_e / (1.09 USD/EUR) .",2023
+nuclear,efficiency,0.326,p.u.,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Based on heat rate of 10.45 MMBtu/MWh_e and 3.4095 MMBtu/MWh_th, i.e. 1/(10.45/3.4095) = 0.3260.",2023
+nuclear,fuel,3.4122,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.",Based on IEA 2011 data.,2010
+nuclear,investment,8594.1354,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","U.S. specific costs including newly commissioned Vogtle plant, average of range and currency converted, i.e. (8475+13925)/2 USD/kW_e / (1.09 USD/EUR) .",2023
+nuclear,lifetime,40,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023
+offwind,FOM,2.3185,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","21 Offshore turbines:  Fixed O&M [EUR/MW_e/y, 2020]",2020
+offwind,VOM,0.0212,EUR/MWhel,RES costs made up to fix curtailment order, from old pypsa cost assumptions,2015
+offwind,investment,1682.1226,"EUR/kW_e, 2020","Danish Energy Agency, technology_data_for_el_and_dh.xlsx","21 Offshore turbines:  Nominal investment [MEUR/MW_e, 2020] grid connection costs substracted from investment costs",2020
+offwind,lifetime,30,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",21 Offshore turbines:  Technical lifetime [years],2020
+offwind-ac-connection-submarine,investment,2841.3251,EUR/MW/km,DEA https://ens.dk/en/our-services/projections-and-models/technology-data, from old pypsa cost assumptions,2015
+offwind-ac-connection-underground,investment,1420.1334,EUR/MW/km,DEA https://ens.dk/en/our-services/projections-and-models/technology-data, from old pypsa cost assumptions,2015
+offwind-ac-station,investment,264.5554,EUR/kWel,DEA https://ens.dk/en/our-services/projections-and-models/technology-data, from old pypsa cost assumptions,2015
+offwind-dc-connection-submarine,investment,2116.4433,EUR/MW/km,DTU report based on Fig 34 of https://ec.europa.eu/energy/sites/ener/files/documents/2014_nsog_report.pdf, from old pypsa cost assumptions,2015
+offwind-dc-connection-underground,investment,1058.2216,EUR/MW/km,Haertel 2017; average + 13% learning reduction, from old pypsa cost assumptions,2015
+offwind-dc-station,investment,423.2887,EUR/kWel,Haertel 2017; assuming one onshore and one offshore node + 13% learning reduction, from old pypsa cost assumptions,2015
+offwind-float,FOM,1.15,%/year,https://doi.org/10.1016/j.adapen.2021.100067,,2020
+offwind-float,investment,2350,EUR/kWel,https://doi.org/10.1016/j.adapen.2021.100067,,2020
+offwind-float,lifetime,20,years,C. Maienza 2020 A life cycle cost model for floating offshore wind farms,,2020
+offwind-float-connection-submarine,investment,2118.5597,EUR/MW/km,DTU report based on Fig 34 of https://ec.europa.eu/energy/sites/ener/files/documents/2014_nsog_report.pdf,,2014
+offwind-float-connection-underground,investment,1039.4778,EUR/MW/km,Haertel 2017, average + 13% learning reduction,2017
+offwind-float-station,investment,415.7911,EUR/kWel,Haertel 2017, assuming one onshore and one offshore node + 13% learning reduction,2017
 oil,CO2 intensity,0.2571,tCO2/MWh_th,Stoichiometric calculation with 44 GJ/t diesel and -CH2- approximation of diesel,,
-oil,FOM,2.463,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",50 Diesel engine farm:  Fixed O&M,2015.0
-oil,VOM,6.3493,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",50 Diesel engine farm:  Variable O&M,2015.0
-oil,efficiency,0.35,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","50 Diesel engine farm:  Electricity efficiency, annual average",2015.0
-oil,fuel,52.9111,EUR/MWhth,IEA WEM2017 97USD/boe = http://www.iea.org/media/weowebsite/2017/WEM_Documentation_WEO2017.pdf, from old pypsa cost assumptions,2015.0
-oil,investment,362.97,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",50 Diesel engine farm:  Specific investment,2015.0
-oil,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",50 Diesel engine farm:  Technical lifetime,2015.0
-onwind,FOM,1.2167,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",20 Onshore turbines:  Fixed O&M,2015.0
-onwind,VOM,1.4286,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",20 Onshore turbines:  Variable O&M,2015.0
-onwind,investment,1095.8533,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",20 Onshore turbines:  Nominal investment ,2015.0
-onwind,lifetime,30.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",20 Onshore turbines:  Technical lifetime,2015.0
-organic rankine cycle,FOM,2.0,%/year,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551","Both for flash, binary and ORC plants. See Supplemental Material for details",2020.0
-organic rankine cycle,electricity-input,0.12,MWh_el/MWh_th,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551; Breede et al. 2015: Overcoming challenges in the classification of deep geothermal potential, https://eprints.gla.ac.uk/169585/","Heat-input, Electricity-output. This is a rough estimate, depends on input temperature, implies ~150 C.",2020.0
-organic rankine cycle,investment,1376.0,EUR/kW_el,Tartiere and Astolfi 2017: A world overview of the organic Rankine cycle market,"Low rollout complicates the estimation, compounded by a dependence both on plant size and temperature, converted from 1500 USD/kW using currency conversion 1.09 USD = 1 EUR.",2020.0
-organic rankine cycle,lifetime,30.0,years,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551",,2020.0
-ror,FOM,2.0,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-ror,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015.0
-ror,investment,3412.2266,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
-ror,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
+oil,FOM,2.463,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",50 Diesel engine farm:  Fixed O&M,2015
+oil,VOM,6.3493,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",50 Diesel engine farm:  Variable O&M,2015
+oil,efficiency,0.35,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","50 Diesel engine farm:  Electricity efficiency, annual average",2015
+oil,fuel,52.9111,EUR/MWhth,IEA WEM2017 97USD/boe = http://www.iea.org/media/weowebsite/2017/WEM_Documentation_WEO2017.pdf, from old pypsa cost assumptions,2015
+oil,investment,362.97,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",50 Diesel engine farm:  Specific investment,2015
+oil,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",50 Diesel engine farm:  Technical lifetime,2015
+onwind,FOM,1.2167,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",20 Onshore turbines:  Fixed O&M,2015
+onwind,VOM,1.4286,EUR/MWh,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",20 Onshore turbines:  Variable O&M,2015
+onwind,investment,1095.8533,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",20 Onshore turbines:  Nominal investment ,2015
+onwind,lifetime,30,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",20 Onshore turbines:  Technical lifetime,2015
+organic rankine cycle,FOM,2,%/year,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551","Both for flash, binary and ORC plants. See Supplemental Material for details",2020
+organic rankine cycle,electricity-input,0.12,MWh_el/MWh_th,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551; Breede et al. 2015: Overcoming challenges in the classification of deep geothermal potential, https://eprints.gla.ac.uk/169585/","Heat-input, Electricity-output. This is a rough estimate, depends on input temperature, implies ~150 C.",2020
+organic rankine cycle,investment,1376,EUR/kW_el,Tartiere and Astolfi 2017: A world overview of the organic Rankine cycle market,"Low rollout complicates the estimation, compounded by a dependence both on plant size and temperature, converted from 1500 USD/kW using currency conversion 1.09 USD = 1 EUR.",2020
+organic rankine cycle,lifetime,30,years,"Aghahosseini, Breyer 2020: From hot rock to useful energy: A global estimate of enhanced geothermal systems potential, https://www.sciencedirect.com/science/article/pii/S0306261920312551",,2020
+ror,FOM,2,%/year,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+ror,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2015
+ror,investment,3412.2266,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010
+ror,lifetime,80,years,IEA2010, from old pypsa cost assumptions,2015
 seawater RO desalination,electricity-input,0.003,MWHh_el/t_H2O,"Caldera et al. (2016): Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",Desalination using SWRO. Assume medium salinity of 35 Practical Salinity Units (PSUs) = 35 kg/m^3.,
-seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+seawater desalination,FOM,4,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2015
 seawater desalination,electricity-input,3.0348,kWh/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",,
-seawater desalination,investment,34796.4978,EUR/(m^3-H2O/h),"Caldera et al 2017: Learning Curve for Seawater Reverse Osmosis Desalination Plants: Capital Cost Trend of the Past, Present, and Future (https://doi.org/10.1002/2017WR021402), Table 4.",,2015.0
-seawater desalination,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
-shipping fuel methanol,CO2 intensity,0.2482,tCO2/MWh_th,-,Based on stochiometric composition.,2020.0
-shipping fuel methanol,fuel,72.0,EUR/MWh_th,"Based on (source 1) Hampp et al (2022), https://arxiv.org/abs/2107.01092, and (source 2): https://www.methanol.org/methanol-price-supply-demand/; both accessed: 2022-12-03.",400 EUR/t assuming range roughly in the long-term range for green methanol (source 1) and late 2020+beyond values for grey methanol (source 2).,2020.0
-solar,FOM,1.9495,%/year,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop' and 50% 'solar-utility',2020.0
-solar,VOM,0.0106,EUR/MWhel,RES costs made up to fix curtailment order, from old pypsa cost assumptions,2015.0
-solar,investment,543.3289,EUR/kW_e,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop' and 50% 'solar-utility',2020.0
-solar,lifetime,40.0,years,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop' and 50% 'solar-utility',2020.0
-solar-rooftop,FOM,1.4234,%/year,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop commercial' and 50% 'solar-rooftop residential',2020.0
-solar-rooftop,discount rate,0.04,per unit,standard for decentral, from old pypsa cost assumptions,2015.0
-solar-rooftop,investment,702.9265,EUR/kW_e,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop commercial' and 50% 'solar-rooftop residential',2020.0
-solar-rooftop,lifetime,40.0,years,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop commercial' and 50% 'solar-rooftop residential',2020.0
-solar-rooftop commercial,FOM,1.573,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV commercial:  Fixed O&M [2020-EUR/MW_e/y],2020.0
-solar-rooftop commercial,investment,565.8069,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV commercial:  Nominal investment [2020-MEUR/MW_e],2020.0
-solar-rooftop commercial,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV commercial:  Technical lifetime [years],2020.0
-solar-rooftop residential,FOM,1.2737,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV residential:  Fixed O&M [2020-EUR/MW_e/y],2020.0
-solar-rooftop residential,investment,840.0461,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV residential:  Nominal investment [2020-MEUR/MW_e],2020.0
-solar-rooftop residential,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV residential:  Technical lifetime [years],2020.0
-solar-utility,FOM,2.4757,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV:  Fixed O&M [2020-EUR/MW_e/y],2020.0
-solar-utility,investment,383.7312,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV:  Nominal investment [2020-MEUR/MW_e],2020.0
-solar-utility,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV:  Technical lifetime [years],2020.0
-solar-utility single-axis tracking,FOM,2.2884,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV tracker:  Fixed O&M [2020-EUR/MW_e/y],2020.0
-solar-utility single-axis tracking,investment,454.4703,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV tracker:  Nominal investment [2020-MEUR/MW_e],2020.0
-solar-utility single-axis tracking,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV tracker:  Technical lifetime [years],2020.0
+seawater desalination,investment,34796.4978,EUR/(m^3-H2O/h),"Caldera et al 2017: Learning Curve for Seawater Reverse Osmosis Desalination Plants: Capital Cost Trend of the Past, Present, and Future (https://doi.org/10.1002/2017WR021402), Table 4.",,2015
+seawater desalination,lifetime,30,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+shipping fuel methanol,CO2 intensity,0.2482,tCO2/MWh_th,-,Based on stochiometric composition.,2020
+shipping fuel methanol,fuel,72,EUR/MWh_th,"Based on (source 1) Hampp et al (2022), https://arxiv.org/abs/2107.01092, and (source 2): https://www.methanol.org/methanol-price-supply-demand/; both accessed: 2022-12-03.",400 EUR/t assuming range roughly in the long-term range for green methanol (source 1) and late 2020+beyond values for grey methanol (source 2).,2020
+solar,FOM,1.9495,%/year,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop' and 50% 'solar-utility',2020
+solar,VOM,0.0106,EUR/MWhel,RES costs made up to fix curtailment order, from old pypsa cost assumptions,2015
+solar,investment,543.3289,EUR/kW_e,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop' and 50% 'solar-utility',2020
+solar,lifetime,40,years,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop' and 50% 'solar-utility',2020
+solar-rooftop,FOM,1.4234,%/year,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop commercial' and 50% 'solar-rooftop residential',2020
+solar-rooftop,discount rate,0.04,per unit,standard for decentral, from old pypsa cost assumptions,2015
+solar-rooftop,investment,702.9265,EUR/kW_e,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop commercial' and 50% 'solar-rooftop residential',2020
+solar-rooftop,lifetime,40,years,Calculated. See 'further description'.,Mixed investment costs based on average of 50% 'solar-rooftop commercial' and 50% 'solar-rooftop residential',2020
+solar-rooftop commercial,FOM,1.573,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV commercial:  Fixed O&M [2020-EUR/MW_e/y],2020
+solar-rooftop commercial,investment,565.8069,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV commercial:  Nominal investment [2020-MEUR/MW_e],2020
+solar-rooftop commercial,lifetime,40,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV commercial:  Technical lifetime [years],2020
+solar-rooftop residential,FOM,1.2737,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV residential:  Fixed O&M [2020-EUR/MW_e/y],2020
+solar-rooftop residential,investment,840.0461,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV residential:  Nominal investment [2020-MEUR/MW_e],2020
+solar-rooftop residential,lifetime,40,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Rooftop PV residential:  Technical lifetime [years],2020
+solar-utility,FOM,2.4757,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV:  Fixed O&M [2020-EUR/MW_e/y],2020
+solar-utility,investment,383.7312,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV:  Nominal investment [2020-MEUR/MW_e],2020
+solar-utility,lifetime,40,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV:  Technical lifetime [years],2020
+solar-utility single-axis tracking,FOM,2.2884,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV tracker:  Fixed O&M [2020-EUR/MW_e/y],2020
+solar-utility single-axis tracking,investment,454.4703,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV tracker:  Nominal investment [2020-MEUR/MW_e],2020
+solar-utility single-axis tracking,lifetime,40,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx",22 Utility-scale PV tracker:  Technical lifetime [years],2020
 solid biomass,CO2 intensity,0.3667,tCO2/MWh_th,Stoichiometric calculation with 18 GJ/t_DM LHV and 50% C-content for solid biomass,,
-solid biomass,fuel,13.6489,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOWOOW1 (secondary forest residue wood chips), ENS_Ref for 2040",,2010.0
-solid biomass boiler steam,FOM,6.0754,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Fixed O&M,2019.0
-solid biomass boiler steam,VOM,2.8448,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Variable O&M,2019.0
-solid biomass boiler steam,efficiency,0.89,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019.0
-solid biomass boiler steam,investment,595.0455,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019.0
-solid biomass boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019.0
-solid biomass boiler steam CC,FOM,6.0754,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Fixed O&M,2019.0
-solid biomass boiler steam CC,VOM,2.8448,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Variable O&M,2019.0
-solid biomass boiler steam CC,efficiency,0.89,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019.0
-solid biomass boiler steam CC,investment,595.0455,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019.0
-solid biomass boiler steam CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019.0
-solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+solid biomass,fuel,13.6489,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOWOOW1 (secondary forest residue wood chips), ENS_Ref for 2040",,2010
+solid biomass boiler steam,FOM,6.0754,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Fixed O&M,2019
+solid biomass boiler steam,VOM,2.8448,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Variable O&M,2019
+solid biomass boiler steam,efficiency,0.89,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019
+solid biomass boiler steam,investment,595.0455,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019
+solid biomass boiler steam,lifetime,25,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019
+solid biomass boiler steam CC,FOM,6.0754,%/year,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Fixed O&M,2019
+solid biomass boiler steam CC,VOM,2.8448,EUR/MWh,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Variable O&M,2019
+solid biomass boiler steam CC,efficiency,0.89,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019
+solid biomass boiler steam CC,investment,595.0455,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019
+solid biomass boiler steam CC,lifetime,25,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019
+solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014
 solid biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 solid biomass to hydrogen,efficiency,0.56,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
-solid biomass to hydrogen,investment,3707.4795,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
-uranium,fuel,3.4122,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.",Based on IEA 2011 data.,2010.0
-waste CHP,FOM,2.355,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Fixed O&M",2015.0
-waste CHP,VOM,28.064,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Variable O&M ",2015.0
-waste CHP,c_b,0.2918,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Cb coefficient",2015.0
-waste CHP,c_v,1.0,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Cv coefficient",2015.0
-waste CHP,efficiency,0.2081,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Electricity efficiency, net, annual average",2015.0
-waste CHP,efficiency-heat,0.7619,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Heat efficiency, net, annual average",2015.0
-waste CHP,investment,8582.5944,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Nominal investment ",2015.0
-waste CHP,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Technical lifetime",2015.0
-waste CHP CC,FOM,2.355,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Fixed O&M",2015.0
-waste CHP CC,VOM,28.064,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Variable O&M ",2015.0
-waste CHP CC,c_b,0.2918,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Cb coefficient",2015.0
-waste CHP CC,c_v,1.0,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Cv coefficient",2015.0
-waste CHP CC,efficiency,0.2081,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Electricity efficiency, net, annual average",2015.0
-waste CHP CC,efficiency-heat,0.7619,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Heat efficiency, net, annual average",2015.0
-waste CHP CC,investment,8582.5944,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Nominal investment ",2015.0
-waste CHP CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Technical lifetime",2015.0
-water tank charger,efficiency,0.9,per unit,HP, from old pypsa cost assumptions,2015.0
-water tank discharger,efficiency,0.9,per unit,HP, from old pypsa cost assumptions,2015.0
+solid biomass to hydrogen,investment,3707.4795,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014
+uranium,fuel,3.4122,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.",Based on IEA 2011 data.,2010
+waste CHP,FOM,2.355,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Fixed O&M",2015
+waste CHP,VOM,28.064,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Variable O&M ",2015
+waste CHP,c_b,0.2918,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Cb coefficient",2015
+waste CHP,c_v,1,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Cv coefficient",2015
+waste CHP,efficiency,0.2081,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Electricity efficiency, net, annual average",2015
+waste CHP,efficiency-heat,0.7619,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Heat efficiency, net, annual average",2015
+waste CHP,investment,8582.5944,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Nominal investment ",2015
+waste CHP,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Technical lifetime",2015
+waste CHP CC,FOM,2.355,%/year,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Fixed O&M",2015
+waste CHP CC,VOM,28.064,EUR/MWh_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Variable O&M ",2015
+waste CHP CC,c_b,0.2918,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Cb coefficient",2015
+waste CHP CC,c_v,1,50°C/100°C,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Cv coefficient",2015
+waste CHP CC,efficiency,0.2081,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Electricity efficiency, net, annual average",2015
+waste CHP CC,efficiency-heat,0.7619,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Heat efficiency, net, annual average",2015
+waste CHP CC,investment,8582.5944,EUR/kW_e,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Nominal investment ",2015
+waste CHP CC,lifetime,25,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","08 WtE CHP, Large, 50 degree:  Technical lifetime",2015
+water tank charger,efficiency,0.9,per unit,HP, from old pypsa cost assumptions,2015
+water tank discharger,efficiency,0.9,per unit,HP, from old pypsa cost assumptions,2015

--- a/outputs/costs_2035.csv
+++ b/outputs/costs_2035.csv
@@ -472,11 +472,11 @@ Pumped-Storage-Hydro-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90
 Pumped-Storage-Hydro-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020.0
 Pumped-Storage-Hydro-store,investment,57074.0625,EUR/MWh,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Reservoir Construction & Infrastructure']}",2020.0
 Pumped-Storage-Hydro-store,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,efficiency,0.76,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR,investment,522201.0492,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,lifetime,30.0,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR CC,capture_rate,0.9,EUR/MW_CH4,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",wide range: capture rates betwen 54%-90%,
 SMR CC,efficiency,0.69,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR CC,investment,605753.2171,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
@@ -742,7 +742,7 @@ central water-sourced heat pump,VOM,1.5768,EUR/MWh,"Danish Energy Agency, techno
 central water-sourced heat pump,efficiency,3.84,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Total efficiency , net, annual average",2015.0
 central water-sourced heat pump,investment,1058.2216,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Specific investment",2015.0
 central water-sourced heat pump,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Technical lifetime",2015.0
-clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,investment,69.1286,EUR/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
 coal,CO2 intensity,0.3361,tCO2/MWh_th,Entwicklung der spezifischen Kohlendioxid-Emissionen des deutschen Strommix in den Jahren 1990 - 2018,,
@@ -752,13 +752,13 @@ coal,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 
 coal,fuel,9.5542,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 99 USD/t.",2010.0
 coal,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR).",2023.0
 coal,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023.0
-csp-tower,FOM,1.2,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,1.0
+csp-tower,FOM,1.2,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,2020.0
 csp-tower,investment,104.17,"EUR/kW_th,dp",ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower,lifetime,30.0,years,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-,2020.0
-csp-tower TES,FOM,1.2,%/year,see solar-tower.,-,1.0
+csp-tower TES,FOM,1.2,%/year,see solar-tower.,-,2020.0
 csp-tower TES,investment,13.955,EUR/kWh_th,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower TES,lifetime,30.0,years,see solar-tower.,-,2020.0
-csp-tower power block,FOM,1.2,%/year,see solar-tower.,-,1.0
+csp-tower power block,FOM,1.2,%/year,see solar-tower.,-,2020.0
 csp-tower power block,investment,729.755,EUR/kW_e,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower power block,lifetime,30.0,years,see solar-tower.,-,2020.0
 decentral CHP,FOM,3.0,%/year,HP, from old pypsa cost assumptions,2015.0
@@ -804,7 +804,7 @@ decentral water tank storage,energy to power ratio,0.15,h,"Danish Energy Agency,
 decentral water tank storage,investment,433.8709,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Specific investment,2015.0
 decentral water tank storage,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Technical lifetime,2015.0
 digestible biomass,fuel,17.0611,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOAGRW1, ENS_Ref for 2040",,2010.0
-digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 digestible biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 digestible biomass to hydrogen,efficiency,0.39,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 digestible biomass to hydrogen,investment,3442.6595,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
@@ -856,7 +856,7 @@ electric boiler steam,VOM,0.8333,EUR/MWh,"Danish Energy Agency, technology_data_
 electric boiler steam,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","310.1 Electric boiler steam  :  Total efficiency, net, annual average",2019.0
 electric boiler steam,investment,70.49,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Nominal investment,2019.0
 electric boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Technical lifetime,2019.0
-electric steam cracker,FOM,3.0,%/year,Guesstimate,,
+electric steam cracker,FOM,3.0,%/year,Guesstimate,,2015.0
 electric steam cracker,VOM,190.4799,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",,2015.0
 electric steam cracker,carbondioxide-output,0.55,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), ",The report also references another source with 0.76 t_CO2/t_HVC,
 electric steam cracker,electricity-input,2.7,MWh_el/t_HVC,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",Assuming electrified processing.,
@@ -870,7 +870,7 @@ electricity grid connection,FOM,2.0,%/year,TODO, from old pypsa cost assumptions
 electricity grid connection,investment,148.151,EUR/kW,DEA, from old pypsa cost assumptions,2015.0
 electricity grid connection,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
 electrobiofuels,C in fuel,0.9281,per unit,Stoichiometric calculation,,
-electrobiofuels,FOM,2.7484,%/year,combination of BtL and electrofuels,,
+electrobiofuels,FOM,2.7484,%/year,combination of BtL and electrofuels,,2015.0
 electrobiofuels,VOM,3.8235,EUR/MWh_th,combination of BtL and electrofuels,,2017.0
 electrobiofuels,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 electrobiofuels,efficiency-biomass,1.3233,per unit,Stoichiometric calculation,,
@@ -978,7 +978,7 @@ methanol-to-kerosene,hydrogen-input,0.0279,MWh_H2/MWh_kerosene,"Concawe (2022): 
 methanol-to-kerosene,investment,251750.0,EUR/MW_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
 methanol-to-kerosene,lifetime,30.0,years,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,
 methanol-to-kerosene,methanol-input,1.0764,MWh_MeOH/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 6.","Assuming LHV 11.94 kWh/kg for kerosene, 5.54 kWh/kg for methanol, 33.3 kWh/kg for hydrogen.",
-methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,
+methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,2015.0
 methanol-to-olefins/aromatics,VOM,31.7466,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", ,2015.0
 methanol-to-olefins/aromatics,carbondioxide-output,0.6107,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 0.4 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 1.13 t_CO2/t_BTX for 15.7 Mt of BTX. The report also references process emissions of 0.55 t_MeOH/t_ethylene+propylene elsewhere. ",
 methanol-to-olefins/aromatics,electricity-input,1.3889,MWh_el/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), page 69",5 GJ/t_HVC ,
@@ -1040,7 +1040,7 @@ ror,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from 
 ror,investment,3412.2266,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
 ror,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
 seawater RO desalination,electricity-input,0.003,MWHh_el/t_H2O,"Caldera et al. (2016): Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",Desalination using SWRO. Assume medium salinity of 35 Practical Salinity Units (PSUs) = 35 kg/m^3.,
-seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2015.0
 seawater desalination,electricity-input,3.0348,kWh/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",,
 seawater desalination,investment,31312.5066,EUR/(m^3-H2O/h),"Caldera et al 2017: Learning Curve for Seawater Reverse Osmosis Desalination Plants: Capital Cost Trend of the Past, Present, and Future (https://doi.org/10.1002/2017WR021402), Table 4.",,2015.0
 seawater desalination,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
@@ -1078,7 +1078,7 @@ solid biomass boiler steam CC,VOM,2.8564,EUR/MWh,"Danish Energy Agency, technolo
 solid biomass boiler steam CC,efficiency,0.89,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019.0
 solid biomass boiler steam CC,investment,581.3136,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019.0
 solid biomass boiler steam CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019.0
-solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 solid biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 solid biomass to hydrogen,efficiency,0.56,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 solid biomass to hydrogen,investment,3442.6595,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0

--- a/outputs/costs_2040.csv
+++ b/outputs/costs_2040.csv
@@ -472,11 +472,11 @@ Pumped-Storage-Hydro-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90
 Pumped-Storage-Hydro-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020.0
 Pumped-Storage-Hydro-store,investment,57074.0625,EUR/MWh,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Reservoir Construction & Infrastructure']}",2020.0
 Pumped-Storage-Hydro-store,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,efficiency,0.76,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR,investment,522201.0492,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,lifetime,30.0,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR CC,capture_rate,0.9,EUR/MW_CH4,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",wide range: capture rates betwen 54%-90%,
 SMR CC,efficiency,0.69,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR CC,investment,605753.2171,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
@@ -742,7 +742,7 @@ central water-sourced heat pump,VOM,1.4709,EUR/MWh,"Danish Energy Agency, techno
 central water-sourced heat pump,efficiency,3.86,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Total efficiency , net, annual average",2015.0
 central water-sourced heat pump,investment,1058.2216,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Specific investment",2015.0
 central water-sourced heat pump,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Technical lifetime",2015.0
-clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,investment,69.1286,EUR/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
 coal,CO2 intensity,0.3361,tCO2/MWh_th,Entwicklung der spezifischen Kohlendioxid-Emissionen des deutschen Strommix in den Jahren 1990 - 2018,,
@@ -752,13 +752,13 @@ coal,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 
 coal,fuel,9.5542,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 99 USD/t.",2010.0
 coal,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR).",2023.0
 coal,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023.0
-csp-tower,FOM,1.3,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,1.0
+csp-tower,FOM,1.3,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,2020.0
 csp-tower,investment,99.97,"EUR/kW_th,dp",ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower,lifetime,30.0,years,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-,2020.0
-csp-tower TES,FOM,1.3,%/year,see solar-tower.,-,1.0
+csp-tower TES,FOM,1.3,%/year,see solar-tower.,-,2020.0
 csp-tower TES,investment,13.39,EUR/kWh_th,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower TES,lifetime,30.0,years,see solar-tower.,-,2020.0
-csp-tower power block,FOM,1.3,%/year,see solar-tower.,-,1.0
+csp-tower power block,FOM,1.3,%/year,see solar-tower.,-,2020.0
 csp-tower power block,investment,700.34,EUR/kW_e,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower power block,lifetime,30.0,years,see solar-tower.,-,2020.0
 decentral CHP,FOM,3.0,%/year,HP, from old pypsa cost assumptions,2015.0
@@ -804,7 +804,7 @@ decentral water tank storage,energy to power ratio,0.15,h,"Danish Energy Agency,
 decentral water tank storage,investment,433.8709,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Specific investment,2015.0
 decentral water tank storage,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Technical lifetime,2015.0
 digestible biomass,fuel,17.0611,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOAGRW1, ENS_Ref for 2040",,2010.0
-digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 digestible biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 digestible biomass to hydrogen,efficiency,0.39,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 digestible biomass to hydrogen,investment,3177.8395,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
@@ -856,7 +856,7 @@ electric boiler steam,VOM,0.7855,EUR/MWh,"Danish Energy Agency, technology_data_
 electric boiler steam,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","310.1 Electric boiler steam  :  Total efficiency, net, annual average",2019.0
 electric boiler steam,investment,70.49,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Nominal investment,2019.0
 electric boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Technical lifetime,2019.0
-electric steam cracker,FOM,3.0,%/year,Guesstimate,,
+electric steam cracker,FOM,3.0,%/year,Guesstimate,,2015.0
 electric steam cracker,VOM,190.4799,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",,2015.0
 electric steam cracker,carbondioxide-output,0.55,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), ",The report also references another source with 0.76 t_CO2/t_HVC,
 electric steam cracker,electricity-input,2.7,MWh_el/t_HVC,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",Assuming electrified processing.,
@@ -870,7 +870,7 @@ electricity grid connection,FOM,2.0,%/year,TODO, from old pypsa cost assumptions
 electricity grid connection,investment,148.151,EUR/kW,DEA, from old pypsa cost assumptions,2015.0
 electricity grid connection,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
 electrobiofuels,C in fuel,0.9292,per unit,Stoichiometric calculation,,
-electrobiofuels,FOM,2.8364,%/year,combination of BtL and electrofuels,,
+electrobiofuels,FOM,2.8364,%/year,combination of BtL and electrofuels,,2015.0
 electrobiofuels,VOM,3.429,EUR/MWh_th,combination of BtL and electrofuels,,2017.0
 electrobiofuels,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 electrobiofuels,efficiency-biomass,1.325,per unit,Stoichiometric calculation,,
@@ -978,7 +978,7 @@ methanol-to-kerosene,hydrogen-input,0.0279,MWh_H2/MWh_kerosene,"Concawe (2022): 
 methanol-to-kerosene,investment,234500.0,EUR/MW_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
 methanol-to-kerosene,lifetime,30.0,years,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,
 methanol-to-kerosene,methanol-input,1.0764,MWh_MeOH/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 6.","Assuming LHV 11.94 kWh/kg for kerosene, 5.54 kWh/kg for methanol, 33.3 kWh/kg for hydrogen.",
-methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,
+methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,2015.0
 methanol-to-olefins/aromatics,VOM,31.7466,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", ,2015.0
 methanol-to-olefins/aromatics,carbondioxide-output,0.6107,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 0.4 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 1.13 t_CO2/t_BTX for 15.7 Mt of BTX. The report also references process emissions of 0.55 t_MeOH/t_ethylene+propylene elsewhere. ",
 methanol-to-olefins/aromatics,electricity-input,1.3889,MWh_el/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), page 69",5 GJ/t_HVC ,
@@ -1040,7 +1040,7 @@ ror,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from 
 ror,investment,3412.2266,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
 ror,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
 seawater RO desalination,electricity-input,0.003,MWHh_el/t_H2O,"Caldera et al. (2016): Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",Desalination using SWRO. Assume medium salinity of 35 Practical Salinity Units (PSUs) = 35 kg/m^3.,
-seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2015.0
 seawater desalination,electricity-input,3.0348,kWh/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",,
 seawater desalination,investment,27828.5154,EUR/(m^3-H2O/h),"Caldera et al 2017: Learning Curve for Seawater Reverse Osmosis Desalination Plants: Capital Cost Trend of the Past, Present, and Future (https://doi.org/10.1002/2017WR021402), Table 4.",,2015.0
 seawater desalination,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
@@ -1078,7 +1078,7 @@ solid biomass boiler steam CC,VOM,2.8679,EUR/MWh,"Danish Energy Agency, technolo
 solid biomass boiler steam CC,efficiency,0.89,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019.0
 solid biomass boiler steam CC,investment,567.5818,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019.0
 solid biomass boiler steam CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019.0
-solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 solid biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 solid biomass to hydrogen,efficiency,0.56,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 solid biomass to hydrogen,investment,3177.8395,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0

--- a/outputs/costs_2045.csv
+++ b/outputs/costs_2045.csv
@@ -472,11 +472,11 @@ Pumped-Storage-Hydro-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90
 Pumped-Storage-Hydro-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020.0
 Pumped-Storage-Hydro-store,investment,57074.0625,EUR/MWh,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Reservoir Construction & Infrastructure']}",2020.0
 Pumped-Storage-Hydro-store,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,efficiency,0.76,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR,investment,522201.0492,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,lifetime,30.0,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR CC,capture_rate,0.9,EUR/MW_CH4,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",wide range: capture rates betwen 54%-90%,
 SMR CC,efficiency,0.69,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR CC,investment,605753.2171,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
@@ -742,7 +742,7 @@ central water-sourced heat pump,VOM,1.4709,EUR/MWh,"Danish Energy Agency, techno
 central water-sourced heat pump,efficiency,3.86,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Total efficiency , net, annual average",2015.0
 central water-sourced heat pump,investment,1058.2216,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Specific investment",2015.0
 central water-sourced heat pump,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Technical lifetime",2015.0
-clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,investment,69.1286,EUR/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
 coal,CO2 intensity,0.3361,tCO2/MWh_th,Entwicklung der spezifischen Kohlendioxid-Emissionen des deutschen Strommix in den Jahren 1990 - 2018,,
@@ -752,13 +752,13 @@ coal,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 
 coal,fuel,9.5542,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 99 USD/t.",2010.0
 coal,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR).",2023.0
 coal,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023.0
-csp-tower,FOM,1.35,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,1.0
+csp-tower,FOM,1.35,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,2020.0
 csp-tower,investment,99.675,"EUR/kW_th,dp",ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower,lifetime,30.0,years,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-,2020.0
-csp-tower TES,FOM,1.35,%/year,see solar-tower.,-,1.0
+csp-tower TES,FOM,1.35,%/year,see solar-tower.,-,2020.0
 csp-tower TES,investment,13.355,EUR/kWh_th,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower TES,lifetime,30.0,years,see solar-tower.,-,2020.0
-csp-tower power block,FOM,1.35,%/year,see solar-tower.,-,1.0
+csp-tower power block,FOM,1.35,%/year,see solar-tower.,-,2020.0
 csp-tower power block,investment,698.27,EUR/kW_e,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower power block,lifetime,30.0,years,see solar-tower.,-,2020.0
 decentral CHP,FOM,3.0,%/year,HP, from old pypsa cost assumptions,2015.0
@@ -804,7 +804,7 @@ decentral water tank storage,energy to power ratio,0.15,h,"Danish Energy Agency,
 decentral water tank storage,investment,433.8709,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Specific investment,2015.0
 decentral water tank storage,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Technical lifetime,2015.0
 digestible biomass,fuel,17.0611,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOAGRW1, ENS_Ref for 2040",,2010.0
-digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 digestible biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 digestible biomass to hydrogen,efficiency,0.39,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 digestible biomass to hydrogen,investment,2913.0196,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
@@ -856,7 +856,7 @@ electric boiler steam,VOM,0.7855,EUR/MWh,"Danish Energy Agency, technology_data_
 electric boiler steam,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","310.1 Electric boiler steam  :  Total efficiency, net, annual average",2019.0
 electric boiler steam,investment,70.49,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Nominal investment,2019.0
 electric boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Technical lifetime,2019.0
-electric steam cracker,FOM,3.0,%/year,Guesstimate,,
+electric steam cracker,FOM,3.0,%/year,Guesstimate,,2015.0
 electric steam cracker,VOM,190.4799,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",,2015.0
 electric steam cracker,carbondioxide-output,0.55,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), ",The report also references another source with 0.76 t_CO2/t_HVC,
 electric steam cracker,electricity-input,2.7,MWh_el/t_HVC,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",Assuming electrified processing.,
@@ -870,7 +870,7 @@ electricity grid connection,FOM,2.0,%/year,TODO, from old pypsa cost assumptions
 electricity grid connection,investment,148.151,EUR/kW,DEA, from old pypsa cost assumptions,2015.0
 electricity grid connection,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
 electrobiofuels,C in fuel,0.9304,per unit,Stoichiometric calculation,,
-electrobiofuels,FOM,2.9164,%/year,combination of BtL and electrofuels,,
+electrobiofuels,FOM,2.9164,%/year,combination of BtL and electrofuels,,2015.0
 electrobiofuels,VOM,3.0103,EUR/MWh_th,combination of BtL and electrofuels,,2017.0
 electrobiofuels,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 electrobiofuels,efficiency-biomass,1.3267,per unit,Stoichiometric calculation,,
@@ -978,7 +978,7 @@ methanol-to-kerosene,hydrogen-input,0.0279,MWh_H2/MWh_kerosene,"Concawe (2022): 
 methanol-to-kerosene,investment,217250.0,EUR/MW_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
 methanol-to-kerosene,lifetime,30.0,years,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,
 methanol-to-kerosene,methanol-input,1.0764,MWh_MeOH/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 6.","Assuming LHV 11.94 kWh/kg for kerosene, 5.54 kWh/kg for methanol, 33.3 kWh/kg for hydrogen.",
-methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,
+methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,2015.0
 methanol-to-olefins/aromatics,VOM,31.7466,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", ,2015.0
 methanol-to-olefins/aromatics,carbondioxide-output,0.6107,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 0.4 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 1.13 t_CO2/t_BTX for 15.7 Mt of BTX. The report also references process emissions of 0.55 t_MeOH/t_ethylene+propylene elsewhere. ",
 methanol-to-olefins/aromatics,electricity-input,1.3889,MWh_el/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), page 69",5 GJ/t_HVC ,
@@ -1040,7 +1040,7 @@ ror,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from 
 ror,investment,3412.2266,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
 ror,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
 seawater RO desalination,electricity-input,0.003,MWHh_el/t_H2O,"Caldera et al. (2016): Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",Desalination using SWRO. Assume medium salinity of 35 Practical Salinity Units (PSUs) = 35 kg/m^3.,
-seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2015.0
 seawater desalination,electricity-input,3.0348,kWh/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",,
 seawater desalination,investment,25039.1517,EUR/(m^3-H2O/h),"Caldera et al 2017: Learning Curve for Seawater Reverse Osmosis Desalination Plants: Capital Cost Trend of the Past, Present, and Future (https://doi.org/10.1002/2017WR021402), Table 4.",,2015.0
 seawater desalination,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
@@ -1078,7 +1078,7 @@ solid biomass boiler steam CC,VOM,2.8679,EUR/MWh,"Danish Energy Agency, technolo
 solid biomass boiler steam CC,efficiency,0.895,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019.0
 solid biomass boiler steam CC,investment,553.85,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019.0
 solid biomass boiler steam CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019.0
-solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 solid biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 solid biomass to hydrogen,efficiency,0.56,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 solid biomass to hydrogen,investment,2913.0196,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0

--- a/outputs/costs_2050.csv
+++ b/outputs/costs_2050.csv
@@ -472,11 +472,11 @@ Pumped-Storage-Hydro-bicharger,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90
 Pumped-Storage-Hydro-store,FOM,0.43,%/year,"Viswanathan_2022, 0.43 % of SB","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['derived']}",2020.0
 Pumped-Storage-Hydro-store,investment,57074.0625,EUR/MWh,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['Reservoir Construction & Infrastructure']}",2020.0
 Pumped-Storage-Hydro-store,lifetime,60.0,years,"Viswanathan_2022, p.68 (p.90)","{'carrier': ['phs'], 'technology_type': ['store'], 'type': ['mechanical'], 'note': ['NULL']}",2020.0
-SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,efficiency,0.76,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR,investment,522201.0492,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR,lifetime,30.0,years,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
-SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",
+SMR CC,FOM,5.0,%/year,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
 SMR CC,capture_rate,0.9,EUR/MW_CH4,"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",wide range: capture rates betwen 54%-90%,
 SMR CC,efficiency,0.69,per unit (in LHV),"IEA Global average levelised cost of hydrogen production by energy source and technology, 2019 and 2050 (2020), https://www.iea.org/data-and-statistics/charts/global-average-levelised-cost-of-hydrogen-production-by-energy-source-and-technology-2019-and-2050",,
 SMR CC,investment,605753.2171,EUR/MW_CH4,Danish Energy Agency,"Technology data for renewable fuels, in pdf on table 3 p.311",2015.0
@@ -742,7 +742,7 @@ central water-sourced heat pump,VOM,1.4709,EUR/MWh,"Danish Energy Agency, techno
 central water-sourced heat pump,efficiency,3.86,per unit,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Total efficiency , net, annual average",2015.0
 central water-sourced heat pump,investment,1058.2216,EUR/kW,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Specific investment",2015.0
 central water-sourced heat pump,lifetime,40.0,years,"Danish Energy Agency, technology_data_for_el_and_dh.xlsx","40 Comp. hp, seawater 20 MW:  Technical lifetime",2015.0
-clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+clean water tank storage,FOM,2.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,investment,69.1286,EUR/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2013.0
 clean water tank storage,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
 coal,CO2 intensity,0.3361,tCO2/MWh_th,Entwicklung der spezifischen Kohlendioxid-Emissionen des deutschen Strommix in den Jahren 1990 - 2018,,
@@ -752,13 +752,13 @@ coal,efficiency,0.33,p.u.,"Lazard's levelized cost of energy analysis - version 
 coal,fuel,9.5542,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 99 USD/t.",2010.0
 coal,investment,3827.1629,EUR/kW_e,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.","Higher costs include coal plants with CCS, but since using here for calculating the average nevertheless. Calculated based on average of listed range, i.e. (3200+6775) USD/kW_e/2 / (1.09 USD/EUR).",2023.0
 coal,lifetime,40.0,years,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",,2023.0
-csp-tower,FOM,1.4,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,1.0
+csp-tower,FOM,1.4,%/year,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),Ratio between CAPEX and FOM from ATB database for “moderate” scenario.,2020.0
 csp-tower,investment,99.38,"EUR/kW_th,dp",ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include solar field and solar tower as well as EPC cost for the default installation size (104 MWe plant). Total costs (223,708,924 USD) are divided by active area (heliostat reflective area, 1,269,054 m2) and multiplied by design point DNI (0.95 kW/m2) to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower,lifetime,30.0,years,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power),-,2020.0
-csp-tower TES,FOM,1.4,%/year,see solar-tower.,-,1.0
+csp-tower TES,FOM,1.4,%/year,see solar-tower.,-,2020.0
 csp-tower TES,investment,13.32,EUR/kWh_th,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the TES incl. EPC cost for the default installation size (104 MWe plant, 2.791 MW_th TES). Total costs (69390776.7 USD) are divided by TES size to obtain EUR/kW_th. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower TES,lifetime,30.0,years,see solar-tower.,-,2020.0
-csp-tower power block,FOM,1.4,%/year,see solar-tower.,-,1.0
+csp-tower power block,FOM,1.4,%/year,see solar-tower.,-,2020.0
 csp-tower power block,investment,696.2,EUR/kW_e,ATB CSP data (https://atb.nrel.gov/electricity/2021/concentrating_solar_power) and NREL SAM v2021.12.2 (https://sam.nrel.gov/).,"Based on NREL’s SAM (v2021.12.2) numbers for a CSP power plant, 2020 numbers. CAPEX degression (=learning) taken from ATB database (“moderate”) scenario. Costs include the power cycle incl. BOP and EPC cost for the default installation size (104 MWe plant). Total costs (135185685.5 USD) are divided by power block nameplate capacity size to obtain EUR/kW_e. Exchange rate: 1.16 USD to 1 EUR.",2020.0
 csp-tower power block,lifetime,30.0,years,see solar-tower.,-,2020.0
 decentral CHP,FOM,3.0,%/year,HP, from old pypsa cost assumptions,2015.0
@@ -804,7 +804,7 @@ decentral water tank storage,energy to power ratio,0.15,h,"Danish Energy Agency,
 decentral water tank storage,investment,433.8709,EUR/kWh,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Specific investment,2015.0
 decentral water tank storage,lifetime,30.0,years,"Danish Energy Agency, technology_data_catalogue_for_energy_storage.xlsx",142 Small scale hot water tank:  Technical lifetime,2015.0
 digestible biomass,fuel,17.0611,EUR/MWh_th,"JRC ENSPRESO ca avg for MINBIOAGRW1, ENS_Ref for 2040",,2010.0
-digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+digestible biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 digestible biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 digestible biomass to hydrogen,efficiency,0.39,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 digestible biomass to hydrogen,investment,2648.1996,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
@@ -856,7 +856,7 @@ electric boiler steam,VOM,0.7855,EUR/MWh,"Danish Energy Agency, technology_data_
 electric boiler steam,efficiency,0.99,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","310.1 Electric boiler steam  :  Total efficiency, net, annual average",2019.0
 electric boiler steam,investment,70.49,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Nominal investment,2019.0
 electric boiler steam,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",310.1 Electric boiler steam  :  Technical lifetime,2019.0
-electric steam cracker,FOM,3.0,%/year,Guesstimate,,
+electric steam cracker,FOM,3.0,%/year,Guesstimate,,2015.0
 electric steam cracker,VOM,190.4799,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35",,2015.0
 electric steam cracker,carbondioxide-output,0.55,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), ",The report also references another source with 0.76 t_CO2/t_HVC,
 electric steam cracker,electricity-input,2.7,MWh_el/t_HVC,"Lechtenböhmer et al. (2016): 10.1016/j.energy.2016.07.110, Section 4.3, page 6.",Assuming electrified processing.,
@@ -870,7 +870,7 @@ electricity grid connection,FOM,2.0,%/year,TODO, from old pypsa cost assumptions
 electricity grid connection,investment,148.151,EUR/kW,DEA, from old pypsa cost assumptions,2015.0
 electricity grid connection,lifetime,40.0,years,TODO, from old pypsa cost assumptions,2015.0
 electrobiofuels,C in fuel,0.9316,per unit,Stoichiometric calculation,,
-electrobiofuels,FOM,3.0,%/year,combination of BtL and electrofuels,,
+electrobiofuels,FOM,3.0,%/year,combination of BtL and electrofuels,,2015.0
 electrobiofuels,VOM,2.6044,EUR/MWh_th,combination of BtL and electrofuels,,2017.0
 electrobiofuels,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 electrobiofuels,efficiency-biomass,1.3283,per unit,Stoichiometric calculation,,
@@ -978,7 +978,7 @@ methanol-to-kerosene,hydrogen-input,0.0279,MWh_H2/MWh_kerosene,"Concawe (2022): 
 methanol-to-kerosene,investment,200000.0,EUR/MW_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,2020.0
 methanol-to-kerosene,lifetime,30.0,years,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 94.",,
 methanol-to-kerosene,methanol-input,1.0764,MWh_MeOH/MWh_kerosene,"Concawe (2022): E-Fuels: A technoeconomic assessment of European domestic production and imports towards 2050 (https://www.concawe.eu/wp-content/uploads/Rpt_22-17.pdf), table 6.","Assuming LHV 11.94 kWh/kg for kerosene, 5.54 kWh/kg for methanol, 33.3 kWh/kg for hydrogen.",
-methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,
+methanol-to-olefins/aromatics,FOM,3.0,%/year,Guesstimate,same as steam cracker,2015.0
 methanol-to-olefins/aromatics,VOM,31.7466,€/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Table 35", ,2015.0
 methanol-to-olefins/aromatics,carbondioxide-output,0.6107,t_CO2/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), Sections 4.5 (for ethylene and propylene) and 4.6 (for BTX)","Weighted average: 0.4 t_MeOH/t_ethylene+propylene for 21.7 Mt of ethylene and 17 Mt of propylene, 1.13 t_CO2/t_BTX for 15.7 Mt of BTX. The report also references process emissions of 0.55 t_MeOH/t_ethylene+propylene elsewhere. ",
 methanol-to-olefins/aromatics,electricity-input,1.3889,MWh_el/t_HVC,"DECHEMA 2017: DECHEMA: Low carbon energy and feedstock for the European chemical industry (https://dechema.de/dechema_media/Downloads/Positionspapiere/Technology_study_Low_carbon_energy_and_feedstock_for_the_European_chemical_industry.pdf), page 69",5 GJ/t_HVC ,
@@ -1040,7 +1040,7 @@ ror,efficiency,0.9,per unit,DIW DataDoc http://hdl.handle.net/10419/80348, from 
 ror,investment,3412.2266,EUR/kWel,DIW DataDoc http://hdl.handle.net/10419/80348, from old pypsa cost assumptions,2010.0
 ror,lifetime,80.0,years,IEA2010, from old pypsa cost assumptions,2015.0
 seawater RO desalination,electricity-input,0.003,MWHh_el/t_H2O,"Caldera et al. (2016): Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",Desalination using SWRO. Assume medium salinity of 35 Practical Salinity Units (PSUs) = 35 kg/m^3.,
-seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
+seawater desalination,FOM,4.0,%/year,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,2015.0
 seawater desalination,electricity-input,3.0348,kWh/m^3-H2O,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Fig. 4.",,
 seawater desalination,investment,22249.7881,EUR/(m^3-H2O/h),"Caldera et al 2017: Learning Curve for Seawater Reverse Osmosis Desalination Plants: Capital Cost Trend of the Past, Present, and Future (https://doi.org/10.1002/2017WR021402), Table 4.",,2015.0
 seawater desalination,lifetime,30.0,years,"Caldera et al 2016: Local cost of seawater RO desalination based on solar PV and windenergy: A global estimate. (https://doi.org/10.1016/j.desal.2016.02.004), Table 1.",,
@@ -1078,7 +1078,7 @@ solid biomass boiler steam CC,VOM,2.8679,EUR/MWh,"Danish Energy Agency, technolo
 solid biomass boiler steam CC,efficiency,0.9,per unit,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx","311.1e Steam boiler Wood:  Total efficiency, net, annual average",2019.0
 solid biomass boiler steam CC,investment,540.1182,EUR/kW,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Nominal investment,2019.0
 solid biomass boiler steam CC,lifetime,25.0,years,"Danish Energy Agency, technology_data_for_industrial_process_heat.xlsx",311.1e Steam boiler Wood:  Technical lifetime,2019.0
-solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
+solid biomass to hydrogen,FOM,4.25,%/year,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0
 solid biomass to hydrogen,capture rate,0.9,per unit,Assumption based on doi:10.1016/j.biombioe.2015.01.006,,
 solid biomass to hydrogen,efficiency,0.56,per unit,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,
 solid biomass to hydrogen,investment,2648.1996,EUR/kW_th,"Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014",,2014.0

--- a/scripts/compile_cost_assumptions.py
+++ b/scripts/compile_cost_assumptions.py
@@ -783,6 +783,7 @@ def add_desalinsation_data(costs):
     costs.loc[(tech, 'FOM'), 'value'] = 4.
     costs.loc[(tech, 'FOM'), 'unit'] = "%/year"
     costs.loc[(tech, 'FOM'), 'source'] = source_dict['Caldera2016'] + ", Table 1."
+    costs.loc[(tech, 'FOM'), 'currency_year'] = 2015
 
     costs.loc[(tech, 'lifetime'), 'value'] = 30
     costs.loc[(tech, 'lifetime'), 'unit'] = "years"
@@ -802,6 +803,7 @@ def add_desalinsation_data(costs):
     costs.loc[(tech, 'FOM'), 'value'] = 2
     costs.loc[(tech, 'FOM'), 'unit'] = "%/year"
     costs.loc[(tech, 'FOM'), 'source'] = source_dict['Caldera2016'] + ", Table 1."
+    costs.loc[(tech, 'FOM'), 'currency_year'] = 2013
 
     costs.loc[(tech, 'lifetime'), 'value'] = 30
     costs.loc[(tech, 'lifetime'), 'unit'] = "years"
@@ -1928,6 +1930,7 @@ def carbon_flow(costs,year):
             eta = 0.39
             FOM = 4.25
             currency_year = 2014
+            costs.loc[(tech, 'FOM'), 'currency_year'] = 2014
             source = 'Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014' #source_dict('HyNOW')
 
         elif tech == 'solid biomass to hydrogen':
@@ -1935,6 +1938,7 @@ def carbon_flow(costs,year):
             eta = 0.56
             FOM = 4.25
             currency_year = 2014
+            costs.loc[(tech, 'FOM'), 'currency_year'] = 2014
             source = 'Zech et.al. DBFZ Report Nr. 19. Hy-NOW - Evaluierung der Verfahren und Technologien für die Bereitstellung von Wasserstoff auf Basis von Biomasse, DBFZ, 2014' #source_dict('HyNOW')
 
         if eta > 0:
@@ -1994,6 +1998,7 @@ def carbon_flow(costs,year):
             FOM = costs.loc[('BtL', 'FOM'), 'value']
             medium_out = 'oil'
             currency_year = costs.loc[('Fischer-Tropsch', 'investment'), "currency_year"]
+            costs.loc[(tech, 'FOM'), 'currency_year'] = 2015
             source = "combination of BtL and electrofuels"
 
         elif tech in ['biogas', 'biogas CC', 'biogas plus hydrogen']:
@@ -2285,6 +2290,7 @@ def add_SMR_data(data):
     SMR_df.loc[(techs, "FOM"), years] = 5
     SMR_df.loc[(techs, "FOM"), "source"] = source_dict["DEA"]
     SMR_df.loc[(techs, "FOM"), "unit"] = "%/year"
+    SMR_df.loc[(techs, "FOM"), "currency_year"] = 2015
     SMR_df.loc[(techs, "FOM"), "further description"] = "Technology data for renewable fuels, in pdf on table 3 p.311"
 
     # investment


### PR DESCRIPTION
Hi! @finozzifa and I noticed some missing `currency_year` values for FOM (even for some technologies for which they were apparently prescribed in `compile_cost_assumptions.py`, but eventually assigned to `investment` only. I fixed this issue working both in `compile_cost_assumptions.py` and `manual_input.csv` according to the original methods for the definition of techno-economic parameters for the technologies interested by this issue.