### PR TITLE
Fix snakemake environment

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -17,6 +17,7 @@ Upcoming Release
 ..   To use the features already you have to use the ``master`` branch.
 
 * Include unit test execution and compile_cost_assumptions_usa.py in ci.yaml (https://github.com/PyPSA/technology-data/pull/174)
+* Align `snakemake` version and the related `mock_snakemake` to PyPSA-Eur (https://github.com/PyPSA/technology-data/pull/177)
 
 `v0.11.0 <https://github.com/PyPSA/technology-data/releases/tag/v0.11.0>`__ (24th January 2025)
 =======================================================================================

--- a/environment.yaml
+++ b/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
 - python>=3.8
 - pip
   # for running the package
-- snakemake-minimal>=8.5
+- snakemake-minimal>=8.5,<8.25 # See https://github.com/snakemake/snakemake/issues/3202
 - pandas>=2.1
 - pypsa
 - pyarrow

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -4,12 +4,8 @@
 
 # coding: utf-8
 
-import os
 import re
 from pathlib import Path
-
-import snakemake as sm
-from snakemake.script import Snakemake
 
 
 class Dict(dict):
@@ -92,6 +88,19 @@ def mock_snakemake(
         keyword arguments fixing the wildcards. Only necessary if wildcards are
         needed.
     """
+    import os
+
+    import snakemake as sm
+    from snakemake.api import Workflow
+    from snakemake.common import SNAKEFILE_CHOICES
+    from snakemake.script import Snakemake
+    from snakemake.settings.types import (
+        ConfigSettings,
+        DAGSettings,
+        ResourceSettings,
+        StorageSettings,
+        WorkflowSettings,
+    )
 
     script_dir = Path(__file__).parent.resolve()
     if root_dir is None:
@@ -111,7 +120,7 @@ def mock_snakemake(
             f" {root_dir} or scripts directory {script_dir}"
         )
     try:
-        for p in sm.SNAKEFILE_CHOICES:
+        for p in SNAKEFILE_CHOICES:
             if os.path.exists(p):
                 snakefile = p
                 break
@@ -120,12 +129,12 @@ def mock_snakemake(
         elif isinstance(configfiles, str):
             configfiles = [configfiles]
 
-        resource_settings = sm.ResourceSettings()
-        config_settings = sm.ConfigSettings(configfiles=map(Path, configfiles))
-        workflow_settings = sm.WorkflowSettings()
-        storage_settings = sm.StorageSettings()
-        dag_settings = sm.DAGSettings(rerun_triggers=[])
-        workflow = sm.Workflow(
+        resource_settings = ResourceSettings()
+        config_settings = ConfigSettings(configfiles=map(Path, configfiles))
+        workflow_settings = WorkflowSettings()
+        storage_settings = StorageSettings()
+        dag_settings = DAGSettings(rerun_triggers=[])
+        workflow = Workflow(
             config_settings,
             resource_settings,
             workflow_settings,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR proposes to align the `snakemake` version and the associated `mock_snakemake` to the one used in PyPSA-Eur. This is necessary to avoid two errors. The first one is reported here https://github.com/PyPSA/pypsa-eur/issues/1439 (related snakemake bug https://github.com/snakemake/snakemake/issues/3202). 

The second is error is thrown with `snakemake=8.27.1` and the current `mock_snakemake. Here is the traceback:
```
Traceback (most recent call last):
  File "technology-data/scripts/compile_cost_assumptions.py", line 3348, in <module>
    snakemake = mock_snakemake("compile_cost_assumptions")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "technology-data/scripts/_helpers.py", line 114, in mock_snakemake
    for p in sm.SNAKEFILE_CHOICES:
             ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'snakemake' has no attribute 'SNAKEFILE_CHOICES'
```

I tested the current suggestion using both the snakemake rule and through terminal.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Data source for new technologies is clearly stated.
- [ ] Newly introduced dependencies are added to `environment.yaml` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the GPLv3 license.
